### PR TITLE
feat(hr): approval-gate personnel orders

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -7,7 +7,7 @@ from alembic import context
 from sqlalchemy import engine_from_config, pool
 
 from morva.persistence.models import Base
-from morva.persistence import core_hr_employment, core_hr_records, domain_extensions, enterprise_models, masterdata_records  # noqa: F401 - register domain tables
+from morva.persistence import approval_records, core_hr_employment, core_hr_records, domain_extensions, enterprise_models, masterdata_records  # noqa: F401 - register domain tables
 
 config = context.config
 if config.config_file_name is not None:

--- a/alembic/versions/0013_personnel_order_approval.py
+++ b/alembic/versions/0013_personnel_order_approval.py
@@ -1,0 +1,48 @@
+"""Personnel order approval tables.
+
+Revision ID: 0013_personnel_order_approval
+Revises: 0012_position_master_data
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0013_personnel_order_approval"
+down_revision = "0012_position_master_data"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "personnel_order_submissions",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("order_id", sa.Uuid(), nullable=False),
+        sa.Column("order_no", sa.String(80), nullable=False),
+        sa.Column("submitted_by", sa.String(100), nullable=False),
+        sa.Column("submitted_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("order_id", name="uq_personnel_order_submission_order"),
+        sa.UniqueConstraint("order_no", name="uq_personnel_order_submission_order_no"),
+    )
+    op.create_index("ix_personnel_order_submissions_order_id", "personnel_order_submissions", ["order_id"])
+    op.create_index("ix_personnel_order_submissions_submitted_by", "personnel_order_submissions", ["submitted_by"])
+
+    op.create_table(
+        "personnel_order_decisions",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("order_id", sa.Uuid(), nullable=False),
+        sa.Column("order_no", sa.String(80), nullable=False),
+        sa.Column("decision", sa.String(20), nullable=False),
+        sa.Column("decided_by", sa.String(100), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("decided_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("order_id", name="uq_personnel_order_decision_order"),
+        sa.UniqueConstraint("order_no", name="uq_personnel_order_decision_order_no"),
+        sa.CheckConstraint("decision IN ('approved', 'rejected')", name="ck_personnel_order_decision_value"),
+    )
+    op.create_index("ix_personnel_order_decisions_order_id", "personnel_order_decisions", ["order_id"])
+    op.create_index("ix_personnel_order_decisions_decided_by", "personnel_order_decisions", ["decided_by"])
+
+
+def downgrade() -> None:
+    op.drop_table("personnel_order_decisions")
+    op.drop_table("personnel_order_submissions")

--- a/docs/IMPLEMENTATION_MATRIX.md
+++ b/docs/IMPLEMENTATION_MATRIX.md
@@ -5,7 +5,7 @@
 | # | Capability | State |
 |---|---|---|
 | 1 | Organization & Position Master Data | authenticated organization/position registry APIs and persisted position master data implemented; authoritative ministry dataset and validation pending |
-| 2 | Personnel Order Workflow | durable immutable effective-dated registry + authenticated create/read API implemented; authoritative order schema/approval workflow pending |
+| 2 | Personnel Order Workflow | durable immutable effective-dated registry + authenticated create/read API + approval-gated effective state with immutable final decision implemented; authoritative order schema/governance pending |
 | 3 | Legal Knowledge Base | implemented foundation; authoritative source verification and approval pending |
 | 4 | Calculation Matrix | foundation; complete legal treatment matrix pending |
 | 5 | 1405 Rule Pack | `review_required` until formal legal/finance approval |
@@ -13,7 +13,7 @@
 | 7 | High-volume Payroll | batch/chunk foundations; target-scale execution evidence pending |
 | 8 | Retro + Jalali | deterministic period/replay foundations; complete snapshot-driven retro pending |
 | 9 | Loans / Debts / Deductions | persisted loan and deduction ledger foundations added; authoritative ledgers/policies pending |
-| 10 | Approval / SoD | permission + privileged + distinct-actor controls implemented; durable enterprise IAM workflow pending |
+| 10 | Approval / SoD | permission + privileged + distinct-actor controls implemented for personnel-order decisions; durable enterprise IAM workflow pending |
 | 11 | SINA Adapter | fail-closed typed contract; official schema/endpoint/credential and staging evidence required |
 | 12 | Accounting / Treasury / Bank | typed six-provider boundary + transactional outbox/inbox foundations; official adapters required |
 | 13 | Employee Self-Service | role-aware RTL web shell and API foundations; complete authenticated production UX pending |
@@ -43,7 +43,7 @@
 
 `Person -> Employee -> Employment -> Organization -> Position -> Assignment -> Education -> Experience -> Dependents`
 
-The current implementation provides the historical persistence models, authenticated read APIs, immutable effective snapshots, durable personnel-order registry, and authenticated organization/position master-data registry APIs for this chain. Authoritative ministry master data, formal personnel-order approval/mutation workflow, and production employee self-service are still pending acceptance evidence.
+The current implementation provides the historical persistence models, authenticated read APIs, immutable effective snapshots, durable personnel-order registry, approval-gated effective orders with immutable final decisions, and authenticated organization/position master-data registry APIs for this chain. Authoritative ministry master data, formal enterprise governance for personnel-order schemas, and production employee self-service are still pending acceptance evidence.
 
 ## Release position
 

--- a/src/morva/api/app.py
+++ b/src/morva/api/app.py
@@ -6,6 +6,7 @@ from morva.api.v1.core_hr import router as core_hr_router
 from morva.api.v1.enterprise import router as enterprise_router
 from morva.api.v1.imports import router as imports_router
 from morva.api.v1.masterdata import router as masterdata_router
+from morva.api.v1.order_approvals import router as order_approvals_router
 from morva.api.v1.payroll import router as payroll_router
 from morva.api.v1.reconciliation import router as reconciliation_router
 from morva.api.v1.rules import router as rules_router
@@ -32,6 +33,7 @@ app.include_router(validation_router, prefix="/api/v1", dependencies=protected_d
 app.include_router(enterprise_router, prefix="/api/v1", dependencies=protected_dependencies)
 app.include_router(core_hr_router, prefix="/api/v1", dependencies=protected_dependencies)
 app.include_router(masterdata_router, prefix="/api/v1", dependencies=protected_dependencies)
+app.include_router(order_approvals_router, prefix="/api/v1", dependencies=protected_dependencies)
 
 
 @app.get("/health", tags=["system"])

--- a/src/morva/api/v1/order_approvals.py
+++ b/src/morva/api/v1/order_approvals.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import date
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -11,7 +10,7 @@ from morva.audit.persistence import append_audit_event
 from morva.persistence.approval_records import PersonnelOrderDecisionRecord
 from morva.persistence.database import SessionLocal
 from morva.persistence.models import AuditEventRecord, EmployeeRecord, PersonnelOrderRecord
-from morva.personnel.order_approval import decide_order, get_approval, status_name
+from morva.personnel.order_approval import decide_order, ensure_submission, get_approval, status_name
 from morva.security.auth import Principal, get_current_principal
 from morva.security.hierarchy import authorize_hierarchical
 
@@ -52,8 +51,6 @@ def _ensure_submission_from_audit(session, order: PersonnelOrderRecord):
     )
     if audit is None or not audit.actor_id:
         raise HTTPException(status_code=409, detail="personnel order has no immutable submission provenance")
-    from morva.personnel.order_approval import ensure_submission
-
     submission = ensure_submission(session, order, audit.actor_id)
     return submission, decision
 
@@ -70,7 +67,10 @@ def get_order_approval(
         submission, decision = get_approval(session, order)
         audit = session.scalar(
             select(AuditEventRecord)
-            .where(AuditEventRecord.event_type == "personnel.order.registered", AuditEventRecord.entity_id == str(order.id))
+            .where(
+                AuditEventRecord.event_type == "personnel.order.registered",
+                AuditEventRecord.entity_id == str(order.id),
+            )
             .order_by(AuditEventRecord.sequence_no.asc())
         )
         submitted_by = submission.submitted_by if submission else (audit.actor_id if audit else None)

--- a/src/morva/api/v1/order_approvals.py
+++ b/src/morva/api/v1/order_approvals.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from morva.audit.persistence import append_audit_event
+from morva.persistence.approval_records import PersonnelOrderDecisionRecord
+from morva.persistence.database import SessionLocal
+from morva.persistence.models import AuditEventRecord, EmployeeRecord, PersonnelOrderRecord
+from morva.personnel.order_approval import decide_order, get_approval, status_name
+from morva.security.auth import Principal, get_current_principal
+from morva.security.hierarchy import authorize_hierarchical
+
+router = APIRouter(prefix="/hr", tags=["personnel-order-approval"])
+
+
+class ApprovalInput(BaseModel):
+    decision: Literal["approved", "rejected"]
+    reason: str | None = Field(default=None, max_length=1000)
+
+
+def _load_order(session, employee_no: str, order_no: str) -> tuple[EmployeeRecord, PersonnelOrderRecord]:
+    employee = session.scalar(select(EmployeeRecord).where(EmployeeRecord.employee_no == employee_no))
+    if employee is None:
+        raise HTTPException(status_code=404, detail="employee not found")
+    order = session.scalar(
+        select(PersonnelOrderRecord).where(
+            PersonnelOrderRecord.employee_no == employee_no,
+            PersonnelOrderRecord.order_no == order_no,
+        )
+    )
+    if order is None:
+        raise HTTPException(status_code=404, detail="personnel order not found")
+    return employee, order
+
+
+def _ensure_submission_from_audit(session, order: PersonnelOrderRecord):
+    submission, decision = get_approval(session, order)
+    if submission is not None:
+        return submission, decision
+    audit = session.scalar(
+        select(AuditEventRecord)
+        .where(
+            AuditEventRecord.event_type == "personnel.order.registered",
+            AuditEventRecord.entity_id == str(order.id),
+        )
+        .order_by(AuditEventRecord.sequence_no.asc())
+    )
+    if audit is None or not audit.actor_id:
+        raise HTTPException(status_code=409, detail="personnel order has no immutable submission provenance")
+    from morva.personnel.order_approval import ensure_submission
+
+    submission = ensure_submission(session, order, audit.actor_id)
+    return submission, decision
+
+
+@router.get("/employees/{employee_no}/orders/{order_no}/approval")
+def get_order_approval(
+    employee_no: str,
+    order_no: str,
+    principal: Principal = Depends(get_current_principal),
+) -> dict[str, object]:
+    with SessionLocal() as session:
+        employee, order = _load_order(session, employee_no, order_no)
+        authorize_hierarchical(session, principal, "personnel.read", employee.organization_unit_id)
+        submission, decision = get_approval(session, order)
+        audit = session.scalar(
+            select(AuditEventRecord)
+            .where(AuditEventRecord.event_type == "personnel.order.registered", AuditEventRecord.entity_id == str(order.id))
+            .order_by(AuditEventRecord.sequence_no.asc())
+        )
+        submitted_by = submission.submitted_by if submission else (audit.actor_id if audit else None)
+        return {
+            "order_no": order.order_no,
+            "status": status_name(decision),
+            "submitted_by": submitted_by,
+            "submitted_at": submission.submitted_at.isoformat() if submission else (audit.created_at.isoformat() if audit else None),
+            "decided_by": decision.decided_by if decision else None,
+            "decided_at": decision.decided_at.isoformat() if decision else None,
+            "reason": decision.reason if decision else None,
+        }
+
+
+@router.post("/employees/{employee_no}/orders/{order_no}/approval", status_code=200)
+def decide_order_approval(
+    employee_no: str,
+    order_no: str,
+    payload: ApprovalInput,
+    principal: Principal = Depends(get_current_principal),
+) -> dict[str, object]:
+    with SessionLocal() as session:
+        employee, order = _load_order(session, employee_no, order_no)
+        authorize_hierarchical(session, principal, "personnel.order.approve", employee.organization_unit_id)
+        _ensure_submission_from_audit(session, order)
+        try:
+            decision: PersonnelOrderDecisionRecord = decide_order(
+                session,
+                order,
+                decided_by=principal.user_id,
+                decision=payload.decision,
+                reason=payload.reason,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        append_audit_event(
+            event_type=f"personnel.order.{payload.decision}",
+            entity_type="personnel_order",
+            entity_id=str(order.id),
+            actor_id=principal.user_id,
+            payload={"order_no": order.order_no, "employee_no": employee_no, "reason": payload.reason},
+            reason=f"personnel order final decision: {payload.decision}",
+            session=session,
+        )
+        session.commit()
+        return {
+            "order_no": order.order_no,
+            "status": decision.decision,
+            "decided_by": decision.decided_by,
+            "decided_at": decision.decided_at.isoformat(),
+            "reason": decision.reason,
+        }

--- a/src/morva/persistence/approval_records.py
+++ b/src/morva/persistence/approval_records.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import DateTime, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .models import Base
+
+
+class PersonnelOrderSubmissionRecord(Base):
+    """Immutable submission provenance for a personnel order."""
+
+    __tablename__ = "personnel_order_submissions"
+    __table_args__ = (UniqueConstraint("order_id", name="uq_personnel_order_submission_order"),)
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    order_id: Mapped[UUID] = mapped_column(index=True)
+    order_no: Mapped[str] = mapped_column(String(80), unique=True, index=True)
+    submitted_by: Mapped[str] = mapped_column(String(100), index=True)
+    submitted_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class PersonnelOrderDecisionRecord(Base):
+    """Append-only final decision. At most one decision exists for an order."""
+
+    __tablename__ = "personnel_order_decisions"
+    __table_args__ = (UniqueConstraint("order_id", name="uq_personnel_order_decision_order"),)
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    order_id: Mapped[UUID] = mapped_column(index=True)
+    order_no: Mapped[str] = mapped_column(String(80), unique=True, index=True)
+    decision: Mapped[str] = mapped_column(String(20))
+    decided_by: Mapped[str] = mapped_column(String(100), index=True)
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    decided_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/src/morva/personnel/order_approval.py
+++ b/src/morva/personnel/order_approval.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from morva.persistence.approval_records import PersonnelOrderDecisionRecord, PersonnelOrderSubmissionRecord
+from morva.persistence.models import PersonnelOrderRecord
+from morva.security.policy import require_distinct_actors
+
+Decision = Literal["approved", "rejected"]
+
+
+def ensure_submission(session: Session, order: PersonnelOrderRecord, submitted_by: str) -> PersonnelOrderSubmissionRecord:
+    existing = session.scalar(
+        select(PersonnelOrderSubmissionRecord).where(PersonnelOrderSubmissionRecord.order_id == order.id)
+    )
+    if existing is not None:
+        return existing
+    submission = PersonnelOrderSubmissionRecord(
+        order_id=order.id,
+        order_no=order.order_no,
+        submitted_by=submitted_by,
+        submitted_at=datetime.utcnow(),
+    )
+    session.add(submission)
+    session.flush()
+    return submission
+
+
+def get_approval(session: Session, order: PersonnelOrderRecord) -> tuple[PersonnelOrderSubmissionRecord | None, PersonnelOrderDecisionRecord | None]:
+    submission = session.scalar(
+        select(PersonnelOrderSubmissionRecord).where(PersonnelOrderSubmissionRecord.order_id == order.id)
+    )
+    decision = session.scalar(
+        select(PersonnelOrderDecisionRecord).where(PersonnelOrderDecisionRecord.order_id == order.id)
+    )
+    return submission, decision
+
+
+def decide_order(
+    session: Session,
+    order: PersonnelOrderRecord,
+    *,
+    decided_by: str,
+    decision: Decision,
+    reason: str | None = None,
+) -> PersonnelOrderDecisionRecord:
+    submission, existing = get_approval(session, order)
+    if submission is None:
+        raise ValueError("personnel order has no submission provenance")
+    if existing is not None:
+        raise ValueError("personnel order already has an immutable final decision")
+    require_distinct_actors([submission.submitted_by, decided_by])
+    result = PersonnelOrderDecisionRecord(
+        order_id=order.id,
+        order_no=order.order_no,
+        decision=decision,
+        decided_by=decided_by,
+        reason=reason,
+        decided_at=datetime.utcnow(),
+    )
+    session.add(result)
+    try:
+        session.flush()
+    except IntegrityError as exc:
+        session.rollback()
+        raise ValueError("personnel order decision already exists") from exc
+    return result
+
+
+def status_name(decision: PersonnelOrderDecisionRecord | None) -> str:
+    return decision.decision if decision is not None else "pending"

--- a/src/morva/personnel/order_approval.py
+++ b/src/morva/personnel/order_approval.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session

--- a/src/morva/personnel/order_registry.py
+++ b/src/morva/personnel/order_registry.py
@@ -6,12 +6,12 @@ from decimal import Decimal
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from morva.persistence.approval_records import PersonnelOrderDecisionRecord, PersonnelOrderSubmissionRecord
+from morva.persistence.approval_records import PersonnelOrderDecisionRecord
 from morva.persistence.models import EmployeeRecord, PersonnelOrderRecord
 from morva.personnel.orders import OrderLine, OrderType, PersonnelOrder
 
 
-def persist_personnel_order(session: Session, order: PersonnelOrder, *, created_by: str | None = None) -> PersonnelOrderRecord:
+def persist_personnel_order(session: Session, order: PersonnelOrder) -> PersonnelOrderRecord:
     order.validate()
     employee = session.scalar(select(EmployeeRecord).where(EmployeeRecord.employee_no == order.employee_no))
     if employee is None:
@@ -37,8 +37,6 @@ def persist_personnel_order(session: Session, order: PersonnelOrder, *, created_
         ):
             raise ValueError("personnel order already exists with different content")
         return existing
-    if not created_by:
-        raise ValueError("personnel order creator is required for new submissions")
     record = PersonnelOrderRecord(
         order_no=order.number,
         employee_no=order.employee_no,
@@ -50,13 +48,6 @@ def persist_personnel_order(session: Session, order: PersonnelOrder, *, created_
         payload=payload,
     )
     session.add(record)
-    session.flush()
-    submission = PersonnelOrderSubmissionRecord(
-        order_id=record.id,
-        order_no=record.order_no,
-        submitted_by=created_by,
-    )
-    session.add(submission)
     session.flush()
     return record
 
@@ -82,10 +73,7 @@ def record_to_personnel_order(record: PersonnelOrderRecord) -> PersonnelOrder:
 def effective_personnel_orders(session: Session, employee_no: str, effective_on: date) -> list[PersonnelOrderRecord]:
     records = session.scalars(
         select(PersonnelOrderRecord)
-        .join(
-            PersonnelOrderDecisionRecord,
-            PersonnelOrderDecisionRecord.order_id == PersonnelOrderRecord.id,
-        )
+        .join(PersonnelOrderDecisionRecord, PersonnelOrderDecisionRecord.order_id == PersonnelOrderRecord.id)
         .where(
             PersonnelOrderRecord.employee_no == employee_no,
             PersonnelOrderRecord.effective_date <= effective_on,

--- a/src/morva/personnel/order_registry.py
+++ b/src/morva/personnel/order_registry.py
@@ -6,11 +6,12 @@ from decimal import Decimal
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from morva.persistence.approval_records import PersonnelOrderDecisionRecord, PersonnelOrderSubmissionRecord
 from morva.persistence.models import EmployeeRecord, PersonnelOrderRecord
 from morva.personnel.orders import OrderLine, OrderType, PersonnelOrder
 
 
-def persist_personnel_order(session: Session, order: PersonnelOrder) -> PersonnelOrderRecord:
+def persist_personnel_order(session: Session, order: PersonnelOrder, *, created_by: str | None = None) -> PersonnelOrderRecord:
     order.validate()
     employee = session.scalar(select(EmployeeRecord).where(EmployeeRecord.employee_no == order.employee_no))
     if employee is None:
@@ -36,6 +37,8 @@ def persist_personnel_order(session: Session, order: PersonnelOrder) -> Personne
         ):
             raise ValueError("personnel order already exists with different content")
         return existing
+    if not created_by:
+        raise ValueError("personnel order creator is required for new submissions")
     record = PersonnelOrderRecord(
         order_no=order.number,
         employee_no=order.employee_no,
@@ -47,6 +50,13 @@ def persist_personnel_order(session: Session, order: PersonnelOrder) -> Personne
         payload=payload,
     )
     session.add(record)
+    session.flush()
+    submission = PersonnelOrderSubmissionRecord(
+        order_id=record.id,
+        order_no=record.order_no,
+        submitted_by=created_by,
+    )
+    session.add(submission)
     session.flush()
     return record
 
@@ -72,7 +82,15 @@ def record_to_personnel_order(record: PersonnelOrderRecord) -> PersonnelOrder:
 def effective_personnel_orders(session: Session, employee_no: str, effective_on: date) -> list[PersonnelOrderRecord]:
     records = session.scalars(
         select(PersonnelOrderRecord)
-        .where(PersonnelOrderRecord.employee_no == employee_no, PersonnelOrderRecord.effective_date <= effective_on)
+        .join(
+            PersonnelOrderDecisionRecord,
+            PersonnelOrderDecisionRecord.order_id == PersonnelOrderRecord.id,
+        )
+        .where(
+            PersonnelOrderRecord.employee_no == employee_no,
+            PersonnelOrderRecord.effective_date <= effective_on,
+            PersonnelOrderDecisionRecord.decision == "approved",
+        )
         .order_by(PersonnelOrderRecord.effective_date.desc(), PersonnelOrderRecord.order_no.desc())
     ).all()
     return [record for record in records if record_to_personnel_order(record).is_effective_on(effective_on)]

--- a/src/morva/security/policy.py
+++ b/src/morva/security/policy.py
@@ -32,13 +32,14 @@ ROLE_PERMISSIONS: dict[str, frozenset[str]] = {
     "payment_releaser": frozenset({"payroll.read", "payroll.payment.release"}),
     "payment_reconciler": frozenset({"payroll.read", "payroll.payment.reconcile"}),
     "hr_admin": frozenset({"personnel.read", "personnel.write", "payroll.read"}),
+    "personnel_approver": frozenset({"personnel.read", "personnel.order.approve"}),
     "auditor": frozenset({"audit.read", "payroll.read"}),
     "admin": frozenset({"*"}),
 }
 
 PRIVILEGED_ROLES = frozenset(
     {
-        "admin", "finance_approver", "payroll_approver", "auditor",
+        "admin", "finance_approver", "payroll_approver", "auditor", "personnel_approver",
         "district_finance", "province_finance", "ministry_finance", "payment_releaser",
         "payment_reconciler",
     }

--- a/tests/test_core_hr_employment.py
+++ b/tests/test_core_hr_employment.py
@@ -18,16 +18,16 @@ def employment(start: date, end: date | None = None, employee_no: str = "E-1") -
 
 
 def test_employment_is_active_on_boundary_dates() -> None:
-    record = employment(date(1405, 1, 1), date(1405, 6, 31))
+    record = employment(date(1405, 1, 1), date(1405, 6, 30))
     assert record.active_on(date(1405, 1, 1))
-    assert record.active_on(date(1405, 6, 31))
+    assert record.active_on(date(1405, 6, 30))
     assert not record.active_on(date(1405, 7, 1))
 
 
 def test_employment_rejects_overlapping_intervals() -> None:
     records = (
-        employment(date(1405, 1, 1), date(1405, 6, 31)),
-        employment(date(1405, 6, 31), None),
+        employment(date(1405, 1, 1), date(1405, 6, 30)),
+        employment(date(1405, 6, 30), None),
     )
     with pytest.raises(ValueError, match="employment intervals overlap"):
         Employment.ensure_non_overlapping(records)

--- a/tests/test_core_hr_profile.py
+++ b/tests/test_core_hr_profile.py
@@ -70,7 +70,7 @@ def test_dependent_effective_boundaries_and_range_validation() -> None:
         relationship=DependentRelationship.SPOUSE,
         name="Dependent B",
         valid_from=date(1404, 7, 1),
-        valid_to=date(1404, 6, 31),
+        valid_to=date(1404, 6, 30),
     )
     with pytest.raises(ValueError, match="valid_to cannot precede valid_from"):
         invalid.validate()

--- a/tests/test_personnel_order_approval_api.py
+++ b/tests/test_personnel_order_approval_api.py
@@ -1,6 +1,7 @@
 from datetime import date
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 
 from morva.api.app import app
@@ -15,7 +16,11 @@ def _principal(user_id: str, role: str = "admin", mfa_verified: bool = True) -> 
     return Principal(user_id=user_id, role=role, scope=Scope.MINISTRY, scope_id="ministry", mfa_verified=mfa_verified)
 
 
-app.dependency_overrides[get_current_principal] = lambda: _principal("order-admin")
+@pytest.fixture(autouse=True)
+def _principal_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(app.dependency_overrides, get_current_principal, lambda: _principal("order-admin"))
+
+
 client = TestClient(app)
 
 
@@ -53,7 +58,6 @@ def test_personnel_order_is_pending_until_distinct_approved():
     assert [item["order_no"] for item in effective_after.json()["items"]] == ["ORD-1405-1001"]
     duplicate = client.post(f"/api/v1/hr/employees/{employee_no}/orders/ORD-1405-1001/approval", json={"decision": "rejected"})
     assert duplicate.status_code == 409
-    app.dependency_overrides[get_current_principal] = lambda: _principal("order-admin")
 
 
 def test_personnel_order_approval_requires_mfa():
@@ -62,7 +66,6 @@ def test_personnel_order_approval_requires_mfa():
     app.dependency_overrides[get_current_principal] = lambda: _principal("order-approver-no-mfa", role="personnel_approver", mfa_verified=False)
     response = client.post(f"/api/v1/hr/employees/{employee_no}/orders/ORD-1405-1002/approval", json={"decision": "approved"})
     assert response.status_code == 403
-    app.dependency_overrides[get_current_principal] = lambda: _principal("order-admin")
 
 
 def test_rejected_personnel_order_never_becomes_effective():
@@ -74,4 +77,3 @@ def test_rejected_personnel_order_never_becomes_effective():
     effective = client.get(f"/api/v1/hr/employees/{employee_no}/orders", params={"effective_on": "2026-02-01"})
     assert effective.status_code == 200
     assert all(item["order_no"] != "ORD-1405-1003" for item in effective.json()["items"])
-    app.dependency_overrides[get_current_principal] = lambda: _principal("order-admin")

--- a/tests/test_personnel_order_approval_api.py
+++ b/tests/test_personnel_order_approval_api.py
@@ -1,0 +1,77 @@
+from datetime import date
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from morva.api.app import app
+from morva.persistence.core_hr_employment import EmploymentRecord
+from morva.persistence.database import SessionLocal, init_db
+from morva.persistence.models import EmployeeRecord
+from morva.security.auth import get_current_principal
+from morva.security.policy import Principal, Scope
+
+
+def _principal(user_id: str, role: str = "admin", mfa_verified: bool = True) -> Principal:
+    return Principal(user_id=user_id, role=role, scope=Scope.MINISTRY, scope_id="ministry", mfa_verified=mfa_verified)
+
+
+app.dependency_overrides[get_current_principal] = lambda: _principal("order-admin")
+client = TestClient(app)
+
+
+def _seed_employee() -> str:
+    init_db()
+    employee_no = "ORD-" + uuid4().hex[:10]
+    with SessionLocal() as session:
+        session.add(EmployeeRecord(employee_no=employee_no, source_employee_key="SRC-" + employee_no, national_id=str(uuid4().int)[-10:], first_name="Order", last_name="Employee", employment_type="permanent", status="active", organization_unit_id="ORG-TEST", position_id="POS-TEST", hire_date=date(2020, 1, 1)))
+        session.add(EmploymentRecord(employee_no=employee_no, employment_type="permanent", organization_unit_id="ORG-TEST", position_id="POS-TEST", starts_on=date(2020, 1, 1), status="active"))
+        session.commit()
+    return employee_no
+
+
+def _create_order(employee_no: str, number: str) -> None:
+    payload = {"number": number, "order_type": "promotion", "issue_date": "2026-01-10", "effective_from": "2026-02-01", "reference": "TODO: NEEDS-LEGAL-SOURCE", "lines": [{"code": "BASE", "amount": "125000000", "rule_code": "TODO: NEEDS-LEGAL-SOURCE"}]}
+    response = client.post(f"/api/v1/hr/employees/{employee_no}/orders", json=payload)
+    assert response.status_code == 201
+
+
+def test_personnel_order_is_pending_until_distinct_approved():
+    employee_no = _seed_employee()
+    _create_order(employee_no, "ORD-1405-1001")
+    pending = client.get(f"/api/v1/hr/employees/{employee_no}/orders/ORD-1405-1001/approval")
+    assert pending.status_code == 200
+    assert pending.json()["status"] == "pending"
+    assert pending.json()["submitted_by"] == "order-admin"
+    effective_before = client.get(f"/api/v1/hr/employees/{employee_no}/orders", params={"effective_on": "2026-02-01"})
+    assert effective_before.status_code == 200 and effective_before.json()["items"] == []
+    same_actor = client.post(f"/api/v1/hr/employees/{employee_no}/orders/ORD-1405-1001/approval", json={"decision": "approved"})
+    assert same_actor.status_code == 409
+    app.dependency_overrides[get_current_principal] = lambda: _principal("order-approver", role="personnel_approver")
+    approved = client.post(f"/api/v1/hr/employees/{employee_no}/orders/ORD-1405-1001/approval", json={"decision": "approved", "reason": "reviewed"})
+    assert approved.status_code == 200
+    effective_after = client.get(f"/api/v1/hr/employees/{employee_no}/orders", params={"effective_on": "2026-02-01"})
+    assert [item["order_no"] for item in effective_after.json()["items"]] == ["ORD-1405-1001"]
+    duplicate = client.post(f"/api/v1/hr/employees/{employee_no}/orders/ORD-1405-1001/approval", json={"decision": "rejected"})
+    assert duplicate.status_code == 409
+    app.dependency_overrides[get_current_principal] = lambda: _principal("order-admin")
+
+
+def test_personnel_order_approval_requires_mfa():
+    employee_no = _seed_employee()
+    _create_order(employee_no, "ORD-1405-1002")
+    app.dependency_overrides[get_current_principal] = lambda: _principal("order-approver-no-mfa", role="personnel_approver", mfa_verified=False)
+    response = client.post(f"/api/v1/hr/employees/{employee_no}/orders/ORD-1405-1002/approval", json={"decision": "approved"})
+    assert response.status_code == 403
+    app.dependency_overrides[get_current_principal] = lambda: _principal("order-admin")
+
+
+def test_rejected_personnel_order_never_becomes_effective():
+    employee_no = _seed_employee()
+    _create_order(employee_no, "ORD-1405-1003")
+    app.dependency_overrides[get_current_principal] = lambda: _principal("order-approver", role="personnel_approver")
+    response = client.post(f"/api/v1/hr/employees/{employee_no}/orders/ORD-1405-1003/approval", json={"decision": "rejected", "reason": "insufficient evidence"})
+    assert response.status_code == 200
+    effective = client.get(f"/api/v1/hr/employees/{employee_no}/orders", params={"effective_on": "2026-02-01"})
+    assert effective.status_code == 200
+    assert all(item["order_no"] != "ORD-1405-1003" for item in effective.json()["items"])
+    app.dependency_overrides[get_current_principal] = lambda: _principal("order-admin")

--- a/tests/test_personnel_orders_api.py
+++ b/tests/test_personnel_orders_api.py
@@ -11,13 +11,12 @@ from morva.persistence.models import EmployeeRecord, PersonnelOrderRecord
 from morva.security.auth import get_current_principal
 from morva.security.policy import Principal, Scope
 
-app.dependency_overrides[get_current_principal] = lambda: Principal(
-    user_id="order-admin",
-    role="admin",
-    scope=Scope.MINISTRY,
-    scope_id="ministry",
-    mfa_verified=True,
-)
+
+def _principal(user_id: str, role: str = "admin", mfa_verified: bool = True) -> Principal:
+    return Principal(user_id=user_id, role=role, scope=Scope.MINISTRY, scope_id="ministry", mfa_verified=mfa_verified)
+
+
+app.dependency_overrides[get_current_principal] = lambda: _principal("order-admin")
 client = TestClient(app)
 
 
@@ -48,8 +47,16 @@ def test_personnel_order_registers_idempotently_and_filters_effective_date():
     assert second.json()["id"] == first.json()["id"]
 
     before = client.get(f"/api/v1/hr/employees/{employee_no}/orders", params={"effective_on": "2026-01-31"})
-    after = client.get(f"/api/v1/hr/employees/{employee_no}/orders", params={"effective_on": "2026-02-01"})
+    pending = client.get(f"/api/v1/hr/employees/{employee_no}/orders", params={"effective_on": "2026-02-01"})
     assert before.status_code == 200 and before.json()["items"] == []
+    assert pending.status_code == 200 and pending.json()["items"] == []
+
+    app.dependency_overrides[get_current_principal] = lambda: _principal("order-approver", role="personnel_approver")
+    approved = client.post(f"/api/v1/hr/employees/{employee_no}/orders/ORD-1405-0001/approval", json={"decision": "approved"})
+    assert approved.status_code == 200
+    app.dependency_overrides[get_current_principal] = lambda: _principal("order-admin")
+
+    after = client.get(f"/api/v1/hr/employees/{employee_no}/orders", params={"effective_on": "2026-02-01"})
     assert after.status_code == 200 and [item["order_no"] for item in after.json()["items"]] == ["ORD-1405-0001"]
 
 


### PR DESCRIPTION
Implements the next Core HR stage without introducing legal assumptions:

- immutable submission provenance for personnel orders
- dedicated approved/rejected decision record
- explicit personnel.order.approve permission with MFA for approvers
- separation of duties between submitter and approver
- effective personnel orders are fail-closed until approved
- immutable final decision (second decision rejected)
- API for approval status and decision
- Alembic migration 0013
- regression and workflow API tests
- implementation matrix updated

No authoritative legal values or ministry master-data values are introduced.