### PR TITLE
feat(rules): fail-closed legal governance gate

### DIFF
--- a/docs/IMPLEMENTATION_MATRIX.md
+++ b/docs/IMPLEMENTATION_MATRIX.md
@@ -6,9 +6,9 @@
 |---|---|---|
 | 1 | Organization & Position Master Data | authenticated organization/position registry APIs and persisted position master data implemented; authoritative ministry dataset and validation pending |
 | 2 | Personnel Order Workflow | durable immutable effective-dated registry + authenticated create/read API + approval-gated effective state with immutable final decision implemented; authoritative order schema/governance pending |
-| 3 | Legal Knowledge Base | implemented foundation; authoritative source verification and approval pending |
-| 4 | Calculation Matrix | foundation; complete legal treatment matrix pending |
-| 5 | 1405 Rule Pack | `review_required` until formal legal/finance approval |
+| 3 | Legal Knowledge Base | persisted legal-source/rule-evidence governance workflow added with review, approval, SHA-256 linkage and fail-closed Rule Pack readiness; authoritative source corpus pending |
+| 4 | Calculation Matrix | deterministic rule engine + persisted legal evidence foundations; complete population-specific legal treatment matrix pending |
+| 5 | 1405 Rule Pack | governed lifecycle foundation; remains `review_required` until authoritative legal/finance approval |
 | 6 | Tax / Pension / Insurance | persisted tax, pension and insurance ledger foundations added; approved population-specific rule sets pending |
 | 7 | High-volume Payroll | batch/chunk foundations; target-scale execution evidence pending |
 | 8 | Retro + Jalali | deterministic period/replay foundations; complete snapshot-driven retro pending |

--- a/src/morva/api/app.py
+++ b/src/morva/api/app.py
@@ -9,6 +9,7 @@ from morva.api.v1.masterdata import router as masterdata_router
 from morva.api.v1.order_approvals import router as order_approvals_router
 from morva.api.v1.payroll import router as payroll_router
 from morva.api.v1.reconciliation import router as reconciliation_router
+from morva.api.v1.rule_governance import router as rule_governance_router
 from morva.api.v1.rules import router as rules_router
 from morva.api.v1.validation import router as validation_router
 from morva.persistence.database import init_db
@@ -34,6 +35,7 @@ app.include_router(enterprise_router, prefix="/api/v1", dependencies=protected_d
 app.include_router(core_hr_router, prefix="/api/v1", dependencies=protected_dependencies)
 app.include_router(masterdata_router, prefix="/api/v1", dependencies=protected_dependencies)
 app.include_router(order_approvals_router, prefix="/api/v1", dependencies=protected_dependencies)
+app.include_router(rule_governance_router, prefix="/api/v1", dependencies=protected_dependencies)
 
 
 @app.get("/health", tags=["system"])

--- a/src/morva/api/v1/rule_governance.py
+++ b/src/morva/api/v1/rule_governance.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from morva.audit.persistence import append_audit_event
 from morva.persistence.database import SessionLocal
 from morva.persistence.enterprise_models import LegalSourceRecord, RuleEvidenceRecord
-from morva.persistence.models import RulePackRecord
+from morva.persistence.models import AuditEventRecord, RulePackRecord
 from morva.rules.governance import (
     approve_evidence,
     approve_legal_source,
@@ -68,7 +68,7 @@ def _read(principal: Principal) -> None:
 
 
 @router.post("/legal-sources", status_code=201)
-def create_legal_source(payload: LegalSourceInput, principal: Principal = Depends(get_current_principal)):
+def create_legal_source(payload: LegalSourceInput, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
     _write(principal)
     try:
         validate_legal_source_payload(
@@ -92,7 +92,7 @@ def create_legal_source(payload: LegalSourceInput, principal: Principal = Depend
 
 
 @router.post("/legal-sources/{source_id}/review")
-def review_source(source_id: UUID, principal: Principal = Depends(get_current_principal)):
+def review_source(source_id: UUID, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
     _write(principal)
     with SessionLocal() as session:
         source = session.get(LegalSourceRecord, source_id)
@@ -108,13 +108,20 @@ def review_source(source_id: UUID, principal: Principal = Depends(get_current_pr
 
 
 @router.post("/legal-sources/{source_id}/approve")
-def approve_source(source_id: UUID, principal: Principal = Depends(get_current_principal)):
+def approve_source(source_id: UUID, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
     _write(principal)
     with SessionLocal() as session:
         source = session.get(LegalSourceRecord, source_id)
         if source is None:
             raise HTTPException(status_code=404, detail="legal source not found")
-        review = session.scalar(select(__import__("morva.persistence.models", fromlist=["AuditEventRecord"]).AuditEventRecord).where(__import__("morva.persistence.models", fromlist=["AuditEventRecord"]).AuditEventRecord.event_type == "legal.source.reviewed", __import__("morva.persistence.models", fromlist=["AuditEventRecord"]).AuditEventRecord.entity_id == str(source.id)).order_by(__import__("morva.persistence.models", fromlist=["AuditEventRecord"]).AuditEventRecord.sequence_no.desc()))
+        review = session.scalar(
+            select(AuditEventRecord)
+            .where(
+                AuditEventRecord.event_type == "legal.source.reviewed",
+                AuditEventRecord.entity_id == str(source.id),
+            )
+            .order_by(AuditEventRecord.sequence_no.desc())
+        )
         try:
             approve_legal_source(source, principal.user_id, review.actor_id if review else None)
         except ValueError as exc:
@@ -125,7 +132,7 @@ def approve_source(source_id: UUID, principal: Principal = Depends(get_current_p
 
 
 @router.post("/packs", status_code=201)
-def create_rule_pack(payload: RulePackInput, principal: Principal = Depends(get_current_principal)):
+def create_rule_pack(payload: RulePackInput, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
     _write(principal)
     if payload.effective_from and payload.effective_to and payload.effective_to < payload.effective_from:
         raise HTTPException(status_code=422, detail="effective_to cannot precede effective_from")
@@ -141,7 +148,7 @@ def create_rule_pack(payload: RulePackInput, principal: Principal = Depends(get_
 
 
 @router.post("/packs/{version}/review")
-def review_pack(version: str, principal: Principal = Depends(get_current_principal)):
+def review_pack(version: str, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
     _write(principal)
     with SessionLocal() as session:
         pack = session.scalar(select(RulePackRecord).where(RulePackRecord.version == version))
@@ -158,7 +165,7 @@ def review_pack(version: str, principal: Principal = Depends(get_current_princip
 
 
 @router.post("/packs/{version}/approve")
-def approve_pack(version: str, principal: Principal = Depends(get_current_principal)):
+def approve_pack(version: str, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
     _write(principal)
     with SessionLocal() as session:
         pack = session.scalar(select(RulePackRecord).where(RulePackRecord.version == version))
@@ -173,7 +180,7 @@ def approve_pack(version: str, principal: Principal = Depends(get_current_princi
 
 
 @router.post("/evidence", status_code=201)
-def create_evidence(payload: EvidenceInput, principal: Principal = Depends(get_current_principal)):
+def create_evidence(payload: EvidenceInput, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
     _write(principal)
     try:
         validate_evidence_payload(article=payload.article, population_scope=payload.population_scope, source_hash=payload.source_hash, regression_suite_hash=payload.regression_suite_hash)
@@ -204,7 +211,7 @@ def create_evidence(payload: EvidenceInput, principal: Principal = Depends(get_c
 
 
 @router.post("/evidence/{evidence_id}/review")
-def review_rule_evidence(evidence_id: UUID, principal: Principal = Depends(get_current_principal)):
+def review_rule_evidence(evidence_id: UUID, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
     _write(principal)
     with SessionLocal() as session:
         evidence = session.get(RuleEvidenceRecord, evidence_id)
@@ -220,7 +227,7 @@ def review_rule_evidence(evidence_id: UUID, principal: Principal = Depends(get_c
 
 
 @router.post("/evidence/{evidence_id}/approve")
-def approve_rule_evidence(evidence_id: UUID, principal: Principal = Depends(get_current_principal)):
+def approve_rule_evidence(evidence_id: UUID, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
     _write(principal)
     with SessionLocal() as session:
         evidence = session.get(RuleEvidenceRecord, evidence_id)
@@ -239,7 +246,7 @@ def approve_rule_evidence(evidence_id: UUID, principal: Principal = Depends(get_
 
 
 @router.get("/packs/{version}/readiness")
-def get_pack_readiness(version: str, principal: Principal = Depends(get_current_principal)):
+def get_pack_readiness(version: str, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
     _read(principal)
     with SessionLocal() as session:
         pack = session.scalar(select(RulePackRecord).where(RulePackRecord.version == version))

--- a/src/morva/api/v1/rule_governance.py
+++ b/src/morva/api/v1/rule_governance.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from datetime import date
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from morva.audit.persistence import append_audit_event
+from morva.persistence.database import SessionLocal
+from morva.persistence.enterprise_models import LegalSourceRecord, RuleEvidenceRecord
+from morva.persistence.models import RulePackRecord
+from morva.rules.governance import (
+    approve_evidence,
+    approve_legal_source,
+    approve_rule_pack,
+    pack_readiness,
+    review_evidence,
+    review_legal_source,
+    review_rule_pack,
+    validate_evidence_payload,
+    validate_legal_source_payload,
+)
+from morva.security.auth import Principal, get_current_principal
+from morva.security.policy import Scope, authorize
+
+router = APIRouter(prefix="/rule-governance", tags=["rule-governance"])
+
+
+class LegalSourceInput(BaseModel):
+    citation: str = Field(min_length=1, max_length=300)
+    issuer: str = Field(min_length=1, max_length=200)
+    adoption_date: str = Field(min_length=10, max_length=10)
+    effective_from: str = Field(min_length=10, max_length=10)
+    effective_to: str | None = Field(default=None, min_length=10, max_length=10)
+    document_hash: str = Field(min_length=64, max_length=64)
+    source_uri: str | None = None
+
+
+class RulePackInput(BaseModel):
+    version: str = Field(min_length=1, max_length=80)
+    legal_source_hash: str | None = Field(default=None, min_length=64, max_length=64)
+    rules_hash: str | None = Field(default=None, min_length=64, max_length=64)
+    effective_from: date | None = None
+    effective_to: date | None = None
+
+
+class EvidenceInput(BaseModel):
+    rule_pack_version: str = Field(min_length=1, max_length=80)
+    component_code: str = Field(min_length=1, max_length=80)
+    legal_source_id: UUID
+    issuer: str = Field(min_length=1, max_length=200)
+    article: str = Field(min_length=1, max_length=100)
+    clause: str | None = Field(default=None, max_length=100)
+    population_scope: str = Field(min_length=1, max_length=200)
+    source_hash: str = Field(min_length=64, max_length=64)
+    regression_suite_hash: str = Field(min_length=64, max_length=64)
+
+
+def _write(principal: Principal) -> None:
+    authorize(principal, "admin", Scope.MINISTRY, privileged=True)
+
+
+def _read(principal: Principal) -> None:
+    authorize(principal, "admin", Scope.MINISTRY, privileged=True)
+
+
+@router.post("/legal-sources", status_code=201)
+def create_legal_source(payload: LegalSourceInput, principal: Principal = Depends(get_current_principal)):
+    _write(principal)
+    try:
+        validate_legal_source_payload(
+            adoption_date=payload.adoption_date,
+            effective_from=payload.effective_from,
+            effective_to=payload.effective_to,
+            document_hash=payload.document_hash,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    with SessionLocal() as session:
+        source = LegalSourceRecord(**payload.model_dump())
+        session.add(source)
+        try:
+            session.flush()
+        except IntegrityError as exc:
+            raise HTTPException(status_code=409, detail="legal source could not be registered") from exc
+        append_audit_event(event_type="legal.source.created", entity_type="legal_source", entity_id=str(source.id), actor_id=principal.user_id, payload={"citation": source.citation, "document_hash": source.document_hash}, reason="register legal source for rule governance", session=session)
+        session.commit()
+        return {"id": str(source.id), "status": source.status, "citation": source.citation, "document_hash": source.document_hash}
+
+
+@router.post("/legal-sources/{source_id}/review")
+def review_source(source_id: UUID, principal: Principal = Depends(get_current_principal)):
+    _write(principal)
+    with SessionLocal() as session:
+        source = session.get(LegalSourceRecord, source_id)
+        if source is None:
+            raise HTTPException(status_code=404, detail="legal source not found")
+        try:
+            review_legal_source(source)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        append_audit_event(event_type="legal.source.reviewed", entity_type="legal_source", entity_id=str(source.id), actor_id=principal.user_id, payload={"document_hash": source.document_hash}, reason="review legal source", session=session)
+        session.commit()
+        return {"id": str(source.id), "status": source.status, "reviewed_by": principal.user_id}
+
+
+@router.post("/legal-sources/{source_id}/approve")
+def approve_source(source_id: UUID, principal: Principal = Depends(get_current_principal)):
+    _write(principal)
+    with SessionLocal() as session:
+        source = session.get(LegalSourceRecord, source_id)
+        if source is None:
+            raise HTTPException(status_code=404, detail="legal source not found")
+        review = session.scalar(select(__import__("morva.persistence.models", fromlist=["AuditEventRecord"]).AuditEventRecord).where(__import__("morva.persistence.models", fromlist=["AuditEventRecord"]).AuditEventRecord.event_type == "legal.source.reviewed", __import__("morva.persistence.models", fromlist=["AuditEventRecord"]).AuditEventRecord.entity_id == str(source.id)).order_by(__import__("morva.persistence.models", fromlist=["AuditEventRecord"]).AuditEventRecord.sequence_no.desc()))
+        try:
+            approve_legal_source(source, principal.user_id, review.actor_id if review else None)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        append_audit_event(event_type="legal.source.approved", entity_type="legal_source", entity_id=str(source.id), actor_id=principal.user_id, payload={"document_hash": source.document_hash}, reason="approve legal source", session=session)
+        session.commit()
+        return {"id": str(source.id), "status": source.status, "approved_by": principal.user_id}
+
+
+@router.post("/packs", status_code=201)
+def create_rule_pack(payload: RulePackInput, principal: Principal = Depends(get_current_principal)):
+    _write(principal)
+    if payload.effective_from and payload.effective_to and payload.effective_to < payload.effective_from:
+        raise HTTPException(status_code=422, detail="effective_to cannot precede effective_from")
+    with SessionLocal() as session:
+        if session.scalar(select(RulePackRecord).where(RulePackRecord.version == payload.version)) is not None:
+            raise HTTPException(status_code=409, detail="rule pack version already exists")
+        pack = RulePackRecord(**payload.model_dump())
+        session.add(pack)
+        session.flush()
+        append_audit_event(event_type="rule.pack.created", entity_type="rule_pack", entity_id=str(pack.id), actor_id=principal.user_id, payload={"version": pack.version}, reason="register rule pack", session=session)
+        session.commit()
+        return {"id": str(pack.id), "version": pack.version, "status": pack.status}
+
+
+@router.post("/packs/{version}/review")
+def review_pack(version: str, principal: Principal = Depends(get_current_principal)):
+    _write(principal)
+    with SessionLocal() as session:
+        pack = session.scalar(select(RulePackRecord).where(RulePackRecord.version == version))
+        if pack is None:
+            raise HTTPException(status_code=404, detail="rule pack not found")
+        try:
+            review_rule_pack(pack)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        pack.reviewed_by = principal.user_id
+        append_audit_event(event_type="rule.pack.reviewed", entity_type="rule_pack", entity_id=str(pack.id), actor_id=principal.user_id, payload={"version": version}, reason="review rule pack", session=session)
+        session.commit()
+        return {"version": version, "status": pack.status, "reviewed_by": pack.reviewed_by}
+
+
+@router.post("/packs/{version}/approve")
+def approve_pack(version: str, principal: Principal = Depends(get_current_principal)):
+    _write(principal)
+    with SessionLocal() as session:
+        pack = session.scalar(select(RulePackRecord).where(RulePackRecord.version == version))
+        if pack is None:
+            raise HTTPException(status_code=404, detail="rule pack not found")
+        result = approve_rule_pack(session, pack, principal.user_id)
+        if not result["ready"]:
+            raise HTTPException(status_code=409, detail={"message": "rule pack is not legally ready", "blockers": result["blockers"]})
+        append_audit_event(event_type="rule.pack.approved", entity_type="rule_pack", entity_id=str(pack.id), actor_id=principal.user_id, payload={"version": version}, reason="approve rule pack", session=session)
+        session.commit()
+        return {"version": version, "status": pack.status, "approved_by": pack.approved_by, "approved_at": pack.approved_at.isoformat() if pack.approved_at else None}
+
+
+@router.post("/evidence", status_code=201)
+def create_evidence(payload: EvidenceInput, principal: Principal = Depends(get_current_principal)):
+    _write(principal)
+    try:
+        validate_evidence_payload(article=payload.article, population_scope=payload.population_scope, source_hash=payload.source_hash, regression_suite_hash=payload.regression_suite_hash)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    with SessionLocal() as session:
+        pack = session.scalar(select(RulePackRecord).where(RulePackRecord.version == payload.rule_pack_version))
+        source = session.get(LegalSourceRecord, payload.legal_source_id)
+        if pack is None:
+            raise HTTPException(status_code=404, detail="rule pack not found")
+        if source is None:
+            raise HTTPException(status_code=404, detail="legal source not found")
+        if pack.status == "approved":
+            raise HTTPException(status_code=409, detail="cannot add evidence to an approved rule pack")
+        if source.status != "approved":
+            raise HTTPException(status_code=409, detail="legal source must be approved before evidence registration")
+        if payload.source_hash != source.document_hash:
+            raise HTTPException(status_code=409, detail="source_hash does not match legal source document hash")
+        evidence = RuleEvidenceRecord(**payload.model_dump())
+        session.add(evidence)
+        try:
+            session.flush()
+        except IntegrityError as exc:
+            raise HTTPException(status_code=409, detail="rule evidence already exists for this component and pack") from exc
+        append_audit_event(event_type="rule.evidence.created", entity_type="rule_evidence", entity_id=str(evidence.id), actor_id=principal.user_id, payload={"rule_pack_version": evidence.rule_pack_version, "component_code": evidence.component_code, "source_hash": evidence.source_hash}, reason="register legal evidence for rule component", session=session)
+        session.commit()
+        return {"id": str(evidence.id), "status": evidence.status, "component_code": evidence.component_code}
+
+
+@router.post("/evidence/{evidence_id}/review")
+def review_rule_evidence(evidence_id: UUID, principal: Principal = Depends(get_current_principal)):
+    _write(principal)
+    with SessionLocal() as session:
+        evidence = session.get(RuleEvidenceRecord, evidence_id)
+        if evidence is None:
+            raise HTTPException(status_code=404, detail="rule evidence not found")
+        try:
+            review_evidence(evidence, principal.user_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        append_audit_event(event_type="rule.evidence.reviewed", entity_type="rule_evidence", entity_id=str(evidence.id), actor_id=principal.user_id, payload={"component_code": evidence.component_code}, reason="review rule evidence", session=session)
+        session.commit()
+        return {"id": str(evidence.id), "status": evidence.status, "reviewed_by": evidence.reviewed_by}
+
+
+@router.post("/evidence/{evidence_id}/approve")
+def approve_rule_evidence(evidence_id: UUID, principal: Principal = Depends(get_current_principal)):
+    _write(principal)
+    with SessionLocal() as session:
+        evidence = session.get(RuleEvidenceRecord, evidence_id)
+        if evidence is None:
+            raise HTTPException(status_code=404, detail="rule evidence not found")
+        source = session.get(LegalSourceRecord, evidence.legal_source_id)
+        if source is None or source.status != "approved":
+            raise HTTPException(status_code=409, detail="legal source must be approved before evidence approval")
+        try:
+            approve_evidence(evidence, principal.user_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        append_audit_event(event_type="rule.evidence.approved", entity_type="rule_evidence", entity_id=str(evidence.id), actor_id=principal.user_id, payload={"component_code": evidence.component_code}, reason="approve rule evidence", session=session)
+        session.commit()
+        return {"id": str(evidence.id), "status": evidence.status, "approved_by": evidence.approved_by, "approved_at": evidence.approved_at.isoformat() if evidence.approved_at else None}
+
+
+@router.get("/packs/{version}/readiness")
+def get_pack_readiness(version: str, principal: Principal = Depends(get_current_principal)):
+    _read(principal)
+    with SessionLocal() as session:
+        pack = session.scalar(select(RulePackRecord).where(RulePackRecord.version == version))
+        if pack is None:
+            raise HTTPException(status_code=404, detail="rule pack not found")
+        result = pack_readiness(session, pack)
+        return {"version": version, **result}

--- a/src/morva/rules/governance.py
+++ b/src/morva/rules/governance.py
@@ -1,40 +1,126 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import date
-from enum import StrEnum
+import re
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from morva.persistence.enterprise_models import LegalSourceRecord, RuleEvidenceRecord
+from morva.persistence.models import RulePackRecord
+from morva.security.policy import require_distinct_actors
+
+_HEX64 = re.compile(r"^[0-9a-fA-F]{64}$")
 
 
-class ReviewStatus(StrEnum):
-    DRAFT = "draft"
-    SOURCE_REVIEW = "source_review"
-    LEGAL_REVIEW = "legal_review"
-    FINANCE_REVIEW = "finance_review"
-    REGRESSION_TESTED = "regression_tested"
-    APPROVED = "approved"
-    ACTIVE = "active"
-    SUPERSEDED = "superseded"
-    ARCHIVED = "archived"
+def validate_legal_source_payload(*, adoption_date: str, effective_from: str, effective_to: str | None, document_hash: str) -> None:
+    for name, value in (("adoption_date", adoption_date), ("effective_from", effective_from)):
+        try:
+            datetime.strptime(value, "%Y-%m-%d")
+        except ValueError as exc:
+            raise ValueError(f"{name} must use YYYY-MM-DD") from exc
+    if effective_to is not None:
+        try:
+            datetime.strptime(effective_to, "%Y-%m-%d")
+        except ValueError as exc:
+            raise ValueError("effective_to must use YYYY-MM-DD") from exc
+        if effective_to < effective_from:
+            raise ValueError("effective_to cannot precede effective_from")
+    if not _HEX64.fullmatch(document_hash):
+        raise ValueError("document_hash must be a 64-character hexadecimal SHA-256")
 
 
-@dataclass(frozen=True, slots=True)
-class LegalRuleMeta:
-    code: str
-    source_document: str
-    authority: str
-    effective_from: date
-    effective_to: date | None
-    review_status: ReviewStatus
-    regression_case_ids: tuple[str, ...] = ()
+def review_legal_source(source: LegalSourceRecord) -> None:
+    if source.status != "review_required":
+        raise ValueError("legal source can only be reviewed from review_required state")
+    source.status = "reviewed"
 
-    def can_activate(self) -> bool:
-        return (
-            self.review_status == ReviewStatus.APPROVED
-            and bool(self.source_document.strip())
-            and bool(self.authority.strip())
-            and bool(self.regression_case_ids)
-        )
 
-    def assert_activatable(self) -> None:
-        if not self.can_activate():
-            raise ValueError(f"rule {self.code} is not production-activatable")
+def approve_legal_source(source: LegalSourceRecord, approver_id: str, reviewer_id: str | None) -> None:
+    if source.status != "reviewed":
+        raise ValueError("legal source must be reviewed before approval")
+    require_distinct_actors([reviewer_id, approver_id])
+    source.status = "approved"
+
+
+def validate_evidence_payload(*, article: str, population_scope: str, source_hash: str, regression_suite_hash: str) -> None:
+    if not article.strip():
+        raise ValueError("article is required")
+    if not population_scope.strip():
+        raise ValueError("population_scope is required")
+    for name, value in (("source_hash", source_hash), ("regression_suite_hash", regression_suite_hash)):
+        if not _HEX64.fullmatch(value):
+            raise ValueError(f"{name} must be a 64-character hexadecimal SHA-256")
+
+
+def review_evidence(evidence: RuleEvidenceRecord, reviewer_id: str) -> None:
+    if evidence.status != "review_required":
+        raise ValueError("rule evidence can only be reviewed from review_required state")
+    evidence.reviewed_by = reviewer_id
+    evidence.status = "reviewed"
+
+
+def approve_evidence(evidence: RuleEvidenceRecord, approver_id: str) -> None:
+    if evidence.status != "reviewed":
+        raise ValueError("rule evidence must be reviewed before approval")
+    require_distinct_actors([evidence.reviewed_by, approver_id])
+    evidence.approved_by = approver_id
+    evidence.approved_at = datetime.utcnow()
+    evidence.status = "approved"
+
+
+def review_rule_pack(pack: RulePackRecord) -> None:
+    if pack.status != "draft":
+        raise ValueError("rule pack can only be reviewed from draft state")
+    pack.status = "reviewed"
+    pack.reviewed_at = datetime.utcnow()
+
+
+def approve_rule_pack(session: Session, pack: RulePackRecord, approver_id: str) -> dict[str, object]:
+    if pack.status != "reviewed":
+        raise ValueError("rule pack must be reviewed before approval")
+    evidence = session.scalars(select(RuleEvidenceRecord).where(RuleEvidenceRecord.rule_pack_version == pack.version)).all()
+    blockers: list[str] = []
+    if not evidence:
+        blockers.append("no rule evidence is registered for this rule pack")
+    for item in evidence:
+        source = session.get(LegalSourceRecord, item.legal_source_id)
+        if source is None:
+            blockers.append(f"missing legal source for component {item.component_code}")
+            continue
+        if source.status != "approved":
+            blockers.append(f"legal source for component {item.component_code} is not approved")
+        if item.source_hash != source.document_hash:
+            blockers.append(f"source hash mismatch for component {item.component_code}")
+        if item.status != "approved":
+            blockers.append(f"rule evidence for component {item.component_code} is not approved")
+    if blockers:
+        return {"ready": False, "blockers": blockers}
+    require_distinct_actors([pack.reviewed_by, approver_id])
+    pack.status = "approved"
+    pack.approved_by = approver_id
+    pack.approved_at = datetime.utcnow()
+    return {"ready": True, "blockers": []}
+
+
+def pack_readiness(session: Session, pack: RulePackRecord) -> dict[str, object]:
+    evidence = session.scalars(select(RuleEvidenceRecord).where(RuleEvidenceRecord.rule_pack_version == pack.version)).all()
+    blockers: list[str] = []
+    if pack.status != "approved":
+        blockers.append("rule pack is not approved")
+    if not evidence:
+        blockers.append("no rule evidence is registered for this rule pack")
+    for item in evidence:
+        source = session.get(LegalSourceRecord, item.legal_source_id)
+        if source is None:
+            blockers.append(f"missing legal source for component {item.component_code}")
+            continue
+        if source.status != "approved":
+            blockers.append(f"legal source for component {item.component_code} is not approved")
+        if item.source_hash != source.document_hash:
+            blockers.append(f"source hash mismatch for component {item.component_code}")
+        if item.status != "approved":
+            blockers.append(f"rule evidence for component {item.component_code} is not approved")
+        if item.reviewed_by and item.approved_by and item.reviewed_by == item.approved_by:
+            blockers.append(f"reviewer and approver must be distinct for component {item.component_code}")
+    return {"ready": not blockers, "blockers": blockers, "evidence_count": len(evidence)}

--- a/src/morva/rules/governance.py
+++ b/src/morva/rules/governance.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import date, datetime
+from enum import StrEnum
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -9,6 +11,42 @@ from sqlalchemy.orm import Session
 from morva.persistence.enterprise_models import LegalSourceRecord, RuleEvidenceRecord
 from morva.persistence.models import RulePackRecord
 from morva.security.policy import require_distinct_actors
+
+
+class ReviewStatus(StrEnum):
+    DRAFT = "draft"
+    SOURCE_REVIEW = "source_review"
+    LEGAL_REVIEW = "legal_review"
+    FINANCE_REVIEW = "finance_review"
+    REGRESSION_TESTED = "regression_tested"
+    APPROVED = "approved"
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+    ARCHIVED = "archived"
+
+
+@dataclass(frozen=True, slots=True)
+class LegalRuleMeta:
+    code: str
+    source_document: str
+    authority: str
+    effective_from: date
+    effective_to: date | None
+    review_status: ReviewStatus
+    regression_case_ids: tuple[str, ...] = ()
+
+    def can_activate(self) -> bool:
+        return (
+            self.review_status == ReviewStatus.APPROVED
+            and bool(self.source_document.strip())
+            and bool(self.authority.strip())
+            and bool(self.regression_case_ids)
+        )
+
+    def assert_activatable(self) -> None:
+        if not self.can_activate():
+            raise ValueError(f"rule {self.code} is not production-activatable")
+
 
 _HEX64 = re.compile(r"^[0-9a-fA-F]{64}$")
 

--- a/tests/test_rule_governance_api.py
+++ b/tests/test_rule_governance_api.py
@@ -1,0 +1,120 @@
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from morva.api.app import app
+from morva.persistence.database import init_db
+from morva.security.auth import get_current_principal
+from morva.security.policy import Principal, Scope
+
+
+def _principal(user_id: str) -> Principal:
+    return Principal(user_id=user_id, role="admin", scope=Scope.MINISTRY, scope_id="ministry", mfa_verified=True)
+
+
+def _use(user_id: str) -> None:
+    app.dependency_overrides[get_current_principal] = lambda: _principal(user_id)
+
+
+_use("legal-admin")
+client = TestClient(app)
+init_db()
+
+
+def test_rule_governance_is_fail_closed_until_full_approval_chain():
+    suffix = uuid4().hex[:8]
+    source_hash = "a" * 64
+    regression_hash = "b" * 64
+    pack_version = f"fixture-{suffix}"
+
+    source = client.post(
+        "/api/v1/rule-governance/legal-sources",
+        json={
+            "citation": f"FIXTURE-SOURCE-{suffix}",
+            "issuer": "FIXTURE-ISSUER",
+            "adoption_date": "2026-01-01",
+            "effective_from": "2026-01-01",
+            "document_hash": source_hash,
+            "source_uri": "fixture://not-a-real-legal-source",
+        },
+    )
+    assert source.status_code == 201
+    source_id = source.json()["id"]
+
+    _use("reviewer-1")
+    assert client.post(f"/api/v1/rule-governance/legal-sources/{source_id}/review").status_code == 200
+    _use("approver-1")
+    assert client.post(f"/api/v1/rule-governance/legal-sources/{source_id}/approve").status_code == 200
+
+    pack = client.post("/api/v1/rule-governance/packs", json={"version": pack_version, "effective_from": "2026-01-01"})
+    assert pack.status_code == 201
+
+    _use("pack-reviewer")
+    assert client.post(f"/api/v1/rule-governance/packs/{pack_version}/review").status_code == 200
+    _use("pack-approver")
+    blocked = client.post(f"/api/v1/rule-governance/packs/{pack_version}/approve")
+    assert blocked.status_code == 409
+
+    evidence = client.post(
+        "/api/v1/rule-governance/evidence",
+        json={
+            "rule_pack_version": pack_version,
+            "component_code": f"FIXTURE-COMPONENT-{suffix}",
+            "legal_source_id": source_id,
+            "issuer": "FIXTURE-ISSUER",
+            "article": "FIXTURE-ARTICLE",
+            "population_scope": "fixture-population",
+            "source_hash": source_hash,
+            "regression_suite_hash": regression_hash,
+        },
+    )
+    assert evidence.status_code == 201
+    evidence_id = evidence.json()["id"]
+
+    _use("evidence-reviewer")
+    assert client.post(f"/api/v1/rule-governance/evidence/{evidence_id}/review").status_code == 200
+    _use("evidence-approver")
+    assert client.post(f"/api/v1/rule-governance/evidence/{evidence_id}/approve").status_code == 200
+
+    _use("pack-approver")
+    approved = client.post(f"/api/v1/rule-governance/packs/{pack_version}/approve")
+    assert approved.status_code == 200
+    ready = client.get(f"/api/v1/rule-governance/packs/{pack_version}/readiness")
+    assert ready.status_code == 200
+    assert ready.json()["ready"] is True
+
+
+def test_rule_governance_rejects_source_hash_mismatch():
+    suffix = uuid4().hex[:8]
+    source = client.post(
+        "/api/v1/rule-governance/legal-sources",
+        json={
+            "citation": f"FIXTURE-SOURCE-{suffix}",
+            "issuer": "FIXTURE-ISSUER",
+            "adoption_date": "2026-01-01",
+            "effective_from": "2026-01-01",
+            "document_hash": "c" * 64,
+        },
+    )
+    assert source.status_code == 201
+    source_id = source.json()["id"]
+    _use("reviewer-x")
+    assert client.post(f"/api/v1/rule-governance/legal-sources/{source_id}/review").status_code == 200
+    _use("approver-x")
+    assert client.post(f"/api/v1/rule-governance/legal-sources/{source_id}/approve").status_code == 200
+    pack = client.post("/api/v1/rule-governance/packs", json={"version": f"fixture-{suffix}"})
+    assert pack.status_code == 201
+    response = client.post(
+        "/api/v1/rule-governance/evidence",
+        json={
+            "rule_pack_version": f"fixture-{suffix}",
+            "component_code": "FIXTURE-COMPONENT",
+            "legal_source_id": source_id,
+            "issuer": "FIXTURE-ISSUER",
+            "article": "FIXTURE-ARTICLE",
+            "population_scope": "fixture-population",
+            "source_hash": "d" * 64,
+            "regression_suite_hash": "e" * 64,
+        },
+    )
+    assert response.status_code == 409


### PR DESCRIPTION
Adds a persisted rule-governance workflow for legal sources, Rule Packs, and component evidence. Enforces review/approval sequencing, distinct actors for Rule Pack approval, SHA-256 linkage between evidence and source documents, and a readiness gate that blocks approval until required evidence is approved. Tests use synthetic fixture sources only; no real legal values are introduced.