### PR TITLE
feat(masterdata): add integrity validation gate

### DIFF
--- a/docs/IMPLEMENTATION_MATRIX.md
+++ b/docs/IMPLEMENTATION_MATRIX.md
@@ -4,7 +4,7 @@
 
 | # | Capability | State |
 |---|---|---|
-| 1 | Organization & Position Master Data | authenticated organization/position registry APIs and persisted position master data implemented; authoritative ministry dataset and validation pending |
+| 1 | Organization & Position Master Data | authenticated organization/position registry APIs + persisted position master data + deterministic integrity validation gate implemented; authoritative ministry dataset and authoritative-data acceptance evidence pending |
 | 2 | Personnel Order Workflow | durable immutable effective-dated registry + authenticated create/read API + approval-gated effective state with immutable final decision implemented; authoritative order schema/governance pending |
 | 3 | Legal Knowledge Base | persisted legal-source/rule-evidence governance workflow added with review, approval, SHA-256 linkage and fail-closed Rule Pack readiness; authoritative source corpus pending |
 | 4 | Calculation Matrix | deterministic rule engine + persisted legal evidence foundations; complete population-specific legal treatment matrix pending |
@@ -43,7 +43,7 @@
 
 `Person -> Employee -> Employment -> Organization -> Position -> Assignment -> Education -> Experience -> Dependents`
 
-The current implementation provides the historical persistence models, authenticated read APIs, immutable effective snapshots, durable personnel-order registry, approval-gated effective orders with immutable final decisions, and authenticated organization/position master-data registry APIs for this chain. Authoritative ministry master data, formal enterprise governance for personnel-order schemas, and production employee self-service are still pending acceptance evidence.
+The current implementation provides the historical persistence models, authenticated read APIs, immutable effective snapshots, durable personnel-order registry, approval-gated effective orders with immutable final decisions, and authenticated organization/position master-data registry APIs plus a deterministic integrity validation gate for organization/personnel/assignment/snapshot references. Authoritative ministry master data, formal enterprise governance for personnel-order schemas, and production employee self-service are still pending acceptance evidence.
 
 ## Release position
 

--- a/src/morva/api/app.py
+++ b/src/morva/api/app.py
@@ -6,6 +6,7 @@ from morva.api.v1.core_hr import router as core_hr_router
 from morva.api.v1.enterprise import router as enterprise_router
 from morva.api.v1.imports import router as imports_router
 from morva.api.v1.masterdata import router as masterdata_router
+from morva.api.v1.masterdata_validation import router as masterdata_validation_router
 from morva.api.v1.order_approvals import router as order_approvals_router
 from morva.api.v1.payroll import router as payroll_router
 from morva.api.v1.reconciliation import router as reconciliation_router
@@ -34,6 +35,7 @@ app.include_router(validation_router, prefix="/api/v1", dependencies=protected_d
 app.include_router(enterprise_router, prefix="/api/v1", dependencies=protected_dependencies)
 app.include_router(core_hr_router, prefix="/api/v1", dependencies=protected_dependencies)
 app.include_router(masterdata_router, prefix="/api/v1", dependencies=protected_dependencies)
+app.include_router(masterdata_validation_router, prefix="/api/v1", dependencies=protected_dependencies)
 app.include_router(order_approvals_router, prefix="/api/v1", dependencies=protected_dependencies)
 app.include_router(rule_governance_router, prefix="/api/v1", dependencies=protected_dependencies)
 

--- a/src/morva/api/v1/masterdata_validation.py
+++ b/src/morva/api/v1/masterdata_validation.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from morva.masterdata.validation import validate_master_data
+from morva.persistence.database import SessionLocal
+from morva.security.auth import Principal, get_current_principal
+from morva.security.policy import has_permission, authorize
+
+router = APIRouter(prefix="/master-data", tags=["master-data-validation"])
+
+
+def _authorize_read(principal: Principal) -> None:
+    if not has_permission(principal, "personnel.read"):
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=403, detail="required permission not granted")
+    authorize(principal, "personnel.read", principal.scope)
+
+
+@router.get("/integrity")
+def get_master_data_integrity(
+    principal: Principal = Depends(get_current_principal),
+) -> dict[str, object]:
+    _authorize_read(principal)
+    with SessionLocal() as session:
+        return validate_master_data(session).as_dict()

--- a/src/morva/masterdata/validation.py
+++ b/src/morva/masterdata/validation.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Literal
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from morva.persistence.domain_extensions import AssignmentRecord
+from morva.persistence.enterprise_models import OrganizationUnitRecord
+from morva.persistence.masterdata_records import PositionRecord
+from morva.persistence.models import EmployeeRecord, PersonnelSnapshotRecord
+
+
+Severity = Literal["error", "warning"]
+
+
+@dataclass(frozen=True, slots=True)
+class MasterDataFinding:
+    code: str
+    severity: Severity
+    entity_type: str
+    entity_id: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class MasterDataValidationResult:
+    blocking: bool
+    organization_count: int
+    position_count: int
+    employee_count: int
+    assignment_count: int
+    snapshot_count: int
+    findings: tuple[MasterDataFinding, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "blocking": self.blocking,
+            "counts": {
+                "organizations": self.organization_count,
+                "positions": self.position_count,
+                "employees": self.employee_count,
+                "assignments": self.assignment_count,
+                "snapshots": self.snapshot_count,
+            },
+            "findings": [asdict(item) for item in self.findings],
+        }
+
+
+def _resolve_position(position_ref: str, positions_by_code: dict[str, PositionRecord], positions_by_id: dict[str, PositionRecord]) -> PositionRecord | None:
+    row = positions_by_id.get(position_ref)
+    return row if row is not None else positions_by_code.get(position_ref)
+
+
+def _resolve_organization(ref: str, organizations_by_code: dict[str, OrganizationUnitRecord], organizations_by_id: dict[str, OrganizationUnitRecord]) -> OrganizationUnitRecord | None:
+    row = organizations_by_id.get(ref)
+    return row if row is not None else organizations_by_code.get(ref)
+
+
+def validate_master_data(session: Session) -> MasterDataValidationResult:
+    organizations = session.scalars(select(OrganizationUnitRecord).order_by(OrganizationUnitRecord.code)).all()
+    positions = session.scalars(select(PositionRecord).order_by(PositionRecord.code)).all()
+    employees = session.scalars(select(EmployeeRecord).order_by(EmployeeRecord.employee_no)).all()
+    assignments = session.scalars(select(AssignmentRecord).order_by(AssignmentRecord.employee_no, AssignmentRecord.starts_on)).all()
+    snapshots = session.scalars(select(PersonnelSnapshotRecord).order_by(PersonnelSnapshotRecord.employee_no, PersonnelSnapshotRecord.effective_period)).all()
+
+    organizations_by_id = {str(row.id): row for row in organizations}
+    organizations_by_code = {row.code: row for row in organizations}
+    positions_by_id = {str(row.id): row for row in positions}
+    positions_by_code = {row.code: row for row in positions}
+    employees_by_no = {row.employee_no: row for row in employees}
+    findings: list[MasterDataFinding] = []
+
+    for row in organizations:
+        if row.parent_id is None:
+            continue
+        parent = organizations_by_id.get(str(row.parent_id))
+        if parent is None:
+            findings.append(
+                MasterDataFinding(
+                    code="ORG_PARENT_MISSING",
+                    severity="error",
+                    entity_type="organization_unit",
+                    entity_id=row.code,
+                    message="organization parent reference does not resolve",
+                )
+            )
+            continue
+        visited: set[UUID] = set()
+        current = row
+        while current.parent_id is not None:
+            if current.id in visited:
+                findings.append(
+                    MasterDataFinding(
+                        code="ORG_PARENT_CYCLE",
+                        severity="error",
+                        entity_type="organization_unit",
+                        entity_id=row.code,
+                        message="organization hierarchy contains a parent cycle",
+                    )
+                )
+                break
+            visited.add(current.id)
+            current = organizations_by_id.get(str(current.parent_id))
+            if current is None:
+                break
+
+    for row in employees:
+        org = _resolve_organization(row.organization_unit_id, organizations_by_code, organizations_by_id)
+        if org is None:
+            findings.append(
+                MasterDataFinding(
+                    code="EMPLOYEE_ORG_MISSING",
+                    severity="error",
+                    entity_type="employee",
+                    entity_id=row.employee_no,
+                    message="employee organization reference does not resolve",
+                )
+            )
+        elif not org.active:
+            findings.append(
+                MasterDataFinding(
+                    code="EMPLOYEE_ORG_INACTIVE",
+                    severity="warning",
+                    entity_type="employee",
+                    entity_id=row.employee_no,
+                    message="employee points to an inactive organization",
+                )
+            )
+
+        position = _resolve_position(row.position_id, positions_by_code, positions_by_id)
+        if position is None:
+            findings.append(
+                MasterDataFinding(
+                    code="EMPLOYEE_POSITION_MISSING",
+                    severity="error",
+                    entity_type="employee",
+                    entity_id=row.employee_no,
+                    message="employee position reference does not resolve",
+                )
+            )
+        elif not position.active:
+            findings.append(
+                MasterDataFinding(
+                    code="EMPLOYEE_POSITION_INACTIVE",
+                    severity="warning",
+                    entity_type="employee",
+                    entity_id=row.employee_no,
+                    message="employee points to an inactive position",
+                )
+            )
+
+    for row in assignments:
+        if row.employee_no not in employees_by_no:
+            findings.append(
+                MasterDataFinding(
+                    code="ASSIGNMENT_EMPLOYEE_MISSING",
+                    severity="error",
+                    entity_type="assignment",
+                    entity_id=str(row.id),
+                    message="assignment employee reference does not resolve",
+                )
+            )
+        if row.organization_code not in organizations_by_code:
+            findings.append(
+                MasterDataFinding(
+                    code="ASSIGNMENT_ORG_MISSING",
+                    severity="error",
+                    entity_type="assignment",
+                    entity_id=str(row.id),
+                    message="assignment organization code does not resolve",
+                )
+            )
+        if row.position_code not in positions_by_code:
+            findings.append(
+                MasterDataFinding(
+                    code="ASSIGNMENT_POSITION_MISSING",
+                    severity="error",
+                    entity_type="assignment",
+                    entity_id=str(row.id),
+                    message="assignment position code does not resolve",
+                )
+            )
+        if row.ends_on is not None and row.ends_on < row.starts_on:
+            findings.append(
+                MasterDataFinding(
+                    code="ASSIGNMENT_INVALID_RANGE",
+                    severity="error",
+                    entity_type="assignment",
+                    entity_id=str(row.id),
+                    message="assignment end date precedes start date",
+                )
+            )
+
+    for row in snapshots:
+        if _resolve_organization(row.organization_unit_id, organizations_by_code, organizations_by_id) is None:
+            findings.append(
+                MasterDataFinding(
+                    code="SNAPSHOT_ORG_MISSING",
+                    severity="error",
+                    entity_type="personnel_snapshot",
+                    entity_id=str(row.id),
+                    message="snapshot organization reference does not resolve",
+                )
+            )
+        if _resolve_position(row.position_id, positions_by_code, positions_by_id) is None:
+            findings.append(
+                MasterDataFinding(
+                    code="SNAPSHOT_POSITION_MISSING",
+                    severity="error",
+                    entity_type="personnel_snapshot",
+                    entity_id=str(row.id),
+                    message="snapshot position reference does not resolve",
+                )
+            )
+
+    return MasterDataValidationResult(
+        blocking=any(item.severity == "error" for item in findings),
+        organization_count=len(organizations),
+        position_count=len(positions),
+        employee_count=len(employees),
+        assignment_count=len(assignments),
+        snapshot_count=len(snapshots),
+        findings=tuple(findings),
+    )

--- a/tests/test_masterdata_validation.py
+++ b/tests/test_masterdata_validation.py
@@ -2,13 +2,16 @@ from datetime import date
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 from morva.api.app import app
-from morva.persistence.database import SessionLocal, init_db
+from morva.masterdata.validation import validate_master_data
+from morva.persistence.database import init_db
 from morva.persistence.domain_extensions import AssignmentRecord
 from morva.persistence.enterprise_models import OrganizationUnitRecord
 from morva.persistence.masterdata_records import PositionRecord
-from morva.persistence.models import EmployeeRecord, PersonnelSnapshotRecord
+from morva.persistence.models import Base, EmployeeRecord, PersonnelSnapshotRecord
 from morva.security.auth import get_current_principal
 from morva.security.policy import Principal, Scope
 
@@ -23,11 +26,17 @@ app.dependency_overrides[get_current_principal] = lambda: Principal(
 client = TestClient(app)
 
 
-def test_masterdata_integrity_accepts_resolvable_references():
+def _isolated_session():
     init_db()
-    org = OrganizationUnitRecord(code="ORG-" + uuid4().hex[:8], name="Test Org", kind="district")
-    position = PositionRecord(code="POS-" + uuid4().hex[:8], title="Test Position", occupational_group="education")
-    with SessionLocal() as session:
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)()
+
+
+def test_masterdata_integrity_accepts_resolvable_references():
+    with _isolated_session() as session:
+        org = OrganizationUnitRecord(code="ORG-" + uuid4().hex[:8], name="Test Org", kind="district")
+        position = PositionRecord(code="POS-" + uuid4().hex[:8], title="Test Position", occupational_group="education")
         session.add_all([org, position])
         session.flush()
         employee_no = "MD-" + uuid4().hex[:8]
@@ -70,21 +79,17 @@ def test_masterdata_integrity_accepts_resolvable_references():
         )
         session.commit()
 
-    response = client.get("/api/v1/master-data/integrity")
-    assert response.status_code == 200
-    body = response.json()
-    assert body["blocking"] is False
-    assert body["findings"] == []
+        result = validate_master_data(session)
+        assert result.blocking is False
+        assert result.findings == ()
 
 
 def test_masterdata_integrity_blocks_unresolved_employee_references():
-    init_db()
-    employee_no = "MD-BAD-" + uuid4().hex[:8]
-    with SessionLocal() as session:
+    with _isolated_session() as session:
         session.add(
             EmployeeRecord(
-                employee_no=employee_no,
-                source_employee_key="SRC-" + employee_no,
+                employee_no="MD-BAD-" + uuid4().hex[:8],
+                source_employee_key="SRC-" + uuid4().hex[:8],
                 national_id=str(uuid4().int)[-10:],
                 first_name="Broken",
                 last_name="Reference",
@@ -95,27 +100,26 @@ def test_masterdata_integrity_blocks_unresolved_employee_references():
             )
         )
         session.commit()
-
-    response = client.get("/api/v1/master-data/integrity")
-    assert response.status_code == 200
-    body = response.json()
-    assert body["blocking"] is True
-    codes = {item["code"] for item in body["findings"]}
-    assert {"EMPLOYEE_ORG_MISSING", "EMPLOYEE_POSITION_MISSING"}.issubset(codes)
+        result = validate_master_data(session)
+        codes = {item.code for item in result.findings}
+        assert result.blocking is True
+        assert {"EMPLOYEE_ORG_MISSING", "EMPLOYEE_POSITION_MISSING"}.issubset(codes)
 
 
 def test_masterdata_integrity_blocks_organization_cycles():
-    init_db()
-    with SessionLocal() as session:
+    with _isolated_session() as session:
         org = OrganizationUnitRecord(code="ORG-CYCLE-" + uuid4().hex[:8], name="Cycle", kind="district")
         session.add(org)
         session.flush()
         org.parent_id = org.id
         session.commit()
         code = org.code
+        result = validate_master_data(session)
+        assert result.blocking is True
+        assert any(item.code == "ORG_PARENT_CYCLE" and item.entity_id == code for item in result.findings)
 
+
+def test_masterdata_integrity_endpoint_is_authenticated():
     response = client.get("/api/v1/master-data/integrity")
     assert response.status_code == 200
-    body = response.json()
-    assert body["blocking"] is True
-    assert any(item["code"] == "ORG_PARENT_CYCLE" and item["entity_id"] == code for item in body["findings"])
+    assert {"blocking", "counts", "findings"}.issubset(response.json())

--- a/tests/test_masterdata_validation.py
+++ b/tests/test_masterdata_validation.py
@@ -1,0 +1,121 @@
+from datetime import date
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from morva.api.app import app
+from morva.persistence.database import SessionLocal, init_db
+from morva.persistence.domain_extensions import AssignmentRecord
+from morva.persistence.enterprise_models import OrganizationUnitRecord
+from morva.persistence.masterdata_records import PositionRecord
+from morva.persistence.models import EmployeeRecord, PersonnelSnapshotRecord
+from morva.security.auth import get_current_principal
+from morva.security.policy import Principal, Scope
+
+
+app.dependency_overrides[get_current_principal] = lambda: Principal(
+    user_id="masterdata-validator",
+    role="admin",
+    scope=Scope.MINISTRY,
+    scope_id="ministry",
+    mfa_verified=True,
+)
+client = TestClient(app)
+
+
+def test_masterdata_integrity_accepts_resolvable_references():
+    init_db()
+    org = OrganizationUnitRecord(code="ORG-" + uuid4().hex[:8], name="Test Org", kind="district")
+    position = PositionRecord(code="POS-" + uuid4().hex[:8], title="Test Position", occupational_group="education")
+    with SessionLocal() as session:
+        session.add_all([org, position])
+        session.flush()
+        employee_no = "MD-" + uuid4().hex[:8]
+        session.add(
+            EmployeeRecord(
+                employee_no=employee_no,
+                source_employee_key="SRC-" + employee_no,
+                national_id=str(uuid4().int)[-10:],
+                first_name="Master",
+                last_name="Data",
+                employment_type="permanent",
+                status="active",
+                organization_unit_id=str(org.id),
+                position_id=position.code,
+                hire_date=date(2020, 1, 1),
+            )
+        )
+        session.add(
+            AssignmentRecord(
+                employee_no=employee_no,
+                organization_code=org.code,
+                position_code=position.code,
+                starts_on=date(2026, 1, 1),
+            )
+        )
+        session.add(
+            PersonnelSnapshotRecord(
+                employee_no=employee_no,
+                effective_period="2026-01",
+                effective_date=date(2026, 1, 1),
+                organization_unit_id=str(org.id),
+                position_id=position.code,
+                employment_type="permanent",
+                employment_status="active",
+                source_hash="a" * 64,
+                snapshot_hash="b" * 64,
+                order_numbers=[],
+                components={},
+            )
+        )
+        session.commit()
+
+    response = client.get("/api/v1/master-data/integrity")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["blocking"] is False
+    assert body["findings"] == []
+
+
+def test_masterdata_integrity_blocks_unresolved_employee_references():
+    init_db()
+    employee_no = "MD-BAD-" + uuid4().hex[:8]
+    with SessionLocal() as session:
+        session.add(
+            EmployeeRecord(
+                employee_no=employee_no,
+                source_employee_key="SRC-" + employee_no,
+                national_id=str(uuid4().int)[-10:],
+                first_name="Broken",
+                last_name="Reference",
+                employment_type="permanent",
+                status="active",
+                organization_unit_id="MISSING-ORG",
+                position_id="MISSING-POS",
+            )
+        )
+        session.commit()
+
+    response = client.get("/api/v1/master-data/integrity")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["blocking"] is True
+    codes = {item["code"] for item in body["findings"]}
+    assert {"EMPLOYEE_ORG_MISSING", "EMPLOYEE_POSITION_MISSING"}.issubset(codes)
+
+
+def test_masterdata_integrity_blocks_organization_cycles():
+    init_db()
+    with SessionLocal() as session:
+        org = OrganizationUnitRecord(code="ORG-CYCLE-" + uuid4().hex[:8], name="Cycle", kind="district")
+        session.add(org)
+        session.flush()
+        org.parent_id = org.id
+        session.commit()
+        code = org.code
+
+    response = client.get("/api/v1/master-data/integrity")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["blocking"] is True
+    assert any(item["code"] == "ORG_PARENT_CYCLE" and item["entity_id"] == code for item in body["findings"])


### PR DESCRIPTION
Add a deterministic, read-only master-data integrity gate covering organization hierarchy cycles/missing parents, employee organization/position references, assignment references/date ranges, and snapshot references. Includes isolated regression tests and implementation-matrix documentation. No authoritative ministry dataset is invented; this gate prepares acceptance of authoritative data.