### PR TITLE
feat: M3 authoritative master-data integrity gate

### DIFF
--- a/src/morva/masterdata/authoritative.py
+++ b/src/morva/masterdata/authoritative.py
@@ -1,17 +1,15 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import date
 from collections import defaultdict
+from dataclasses import asdict, dataclass
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from morva.masterdata.validation import MasterDataFinding, validate_master_data
 from morva.persistence.domain_extensions import AssignmentRecord
-from morva.persistence.enterprise_models import OrganizationUnitRecord
 from morva.persistence.masterdata_records import PositionRecord
 from morva.persistence.models import EmployeeRecord
-from morva.masterdata.validation import MasterDataFinding, validate_master_data
 
 
 @dataclass(frozen=True, slots=True)
@@ -22,13 +20,14 @@ class AuthoritativeMasterDataResult:
     def as_dict(self) -> dict[str, object]:
         return {
             "blocking": self.blocking,
-            "findings": [finding.__dict__ for finding in self.findings],
+            "findings": [asdict(finding) for finding in self.findings],
         }
 
 
 def validate_authoritative_master_data(session: Session) -> AuthoritativeMasterDataResult:
     base = validate_master_data(session)
     findings = list(base.findings)
+    additional_blocking = False
 
     positions = session.scalars(select(PositionRecord).order_by(PositionRecord.code)).all()
     for row in positions:
@@ -42,9 +41,14 @@ def validate_authoritative_master_data(session: Session) -> AuthoritativeMasterD
                     message="position effective_to precedes effective_from",
                 )
             )
+            additional_blocking = True
 
     assignments = session.scalars(
-        select(AssignmentRecord).order_by(AssignmentRecord.employee_no, AssignmentRecord.starts_on, AssignmentRecord.id)
+        select(AssignmentRecord).order_by(
+            AssignmentRecord.employee_no,
+            AssignmentRecord.starts_on,
+            AssignmentRecord.id,
+        )
     ).all()
     by_employee: dict[str, list[AssignmentRecord]] = defaultdict(list)
     for row in assignments:
@@ -53,20 +57,17 @@ def validate_authoritative_master_data(session: Session) -> AuthoritativeMasterD
     for employee_no, rows in by_employee.items():
         previous: AssignmentRecord | None = None
         for current in rows:
-            if previous is not None:
-                previous_end = previous.ends_on
-                if previous_end is None or current.starts_on <= previous_end:
-                    findings.append(
-                        MasterDataFinding(
-                            code="ASSIGNMENT_OVERLAP",
-                            severity="error",
-                            entity_type="assignment",
-                            entity_id=str(current.id),
-                            message=(
-                                f"assignment interval overlaps previous assignment for employee {employee_no}"
-                            ),
-                        )
+            if previous is not None and (previous.ends_on is None or current.starts_on <= previous.ends_on):
+                findings.append(
+                    MasterDataFinding(
+                        code="ASSIGNMENT_OVERLAP",
+                        severity="error",
+                        entity_type="assignment",
+                        entity_id=str(current.id),
+                        message=f"assignment interval overlaps previous assignment for employee {employee_no}",
                     )
+                )
+                additional_blocking = True
             previous = current
 
     active_employees = session.scalars(
@@ -84,8 +85,9 @@ def validate_authoritative_master_data(session: Session) -> AuthoritativeMasterD
                     message="active employee has no personnel assignment",
                 )
             )
+            additional_blocking = True
 
     return AuthoritativeMasterDataResult(
-        blocking=base.blocking or any(item.severity == "error" for item in findings if item not in base.findings),
+        blocking=base.blocking or additional_blocking,
         findings=tuple(findings),
     )

--- a/src/morva/masterdata/authoritative.py
+++ b/src/morva/masterdata/authoritative.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from collections import defaultdict
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from morva.persistence.domain_extensions import AssignmentRecord
+from morva.persistence.enterprise_models import OrganizationUnitRecord
+from morva.persistence.masterdata_records import PositionRecord
+from morva.persistence.models import EmployeeRecord
+from morva.masterdata.validation import MasterDataFinding, validate_master_data
+
+
+@dataclass(frozen=True, slots=True)
+class AuthoritativeMasterDataResult:
+    blocking: bool
+    findings: tuple[MasterDataFinding, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "blocking": self.blocking,
+            "findings": [finding.__dict__ for finding in self.findings],
+        }
+
+
+def validate_authoritative_master_data(session: Session) -> AuthoritativeMasterDataResult:
+    base = validate_master_data(session)
+    findings = list(base.findings)
+
+    positions = session.scalars(select(PositionRecord).order_by(PositionRecord.code)).all()
+    for row in positions:
+        if row.effective_to is not None and row.effective_from is not None and row.effective_to < row.effective_from:
+            findings.append(
+                MasterDataFinding(
+                    code="POSITION_INVALID_RANGE",
+                    severity="error",
+                    entity_type="position",
+                    entity_id=row.code,
+                    message="position effective_to precedes effective_from",
+                )
+            )
+
+    assignments = session.scalars(
+        select(AssignmentRecord).order_by(AssignmentRecord.employee_no, AssignmentRecord.starts_on, AssignmentRecord.id)
+    ).all()
+    by_employee: dict[str, list[AssignmentRecord]] = defaultdict(list)
+    for row in assignments:
+        by_employee[row.employee_no].append(row)
+
+    for employee_no, rows in by_employee.items():
+        previous: AssignmentRecord | None = None
+        for current in rows:
+            if previous is not None:
+                previous_end = previous.ends_on
+                if previous_end is None or current.starts_on <= previous_end:
+                    findings.append(
+                        MasterDataFinding(
+                            code="ASSIGNMENT_OVERLAP",
+                            severity="error",
+                            entity_type="assignment",
+                            entity_id=str(current.id),
+                            message=(
+                                f"assignment interval overlaps previous assignment for employee {employee_no}"
+                            ),
+                        )
+                    )
+            previous = current
+
+    active_employees = session.scalars(
+        select(EmployeeRecord).where(EmployeeRecord.status == "active").order_by(EmployeeRecord.employee_no)
+    ).all()
+    assigned_employees = set(by_employee)
+    for employee in active_employees:
+        if employee.employee_no not in assigned_employees:
+            findings.append(
+                MasterDataFinding(
+                    code="ACTIVE_EMPLOYEE_NO_ASSIGNMENT",
+                    severity="error",
+                    entity_type="employee",
+                    entity_id=employee.employee_no,
+                    message="active employee has no personnel assignment",
+                )
+            )
+
+    return AuthoritativeMasterDataResult(
+        blocking=base.blocking or any(item.severity == "error" for item in findings if item not in base.findings),
+        findings=tuple(findings),
+    )

--- a/tests/test_masterdata_authoritative.py
+++ b/tests/test_masterdata_authoritative.py
@@ -1,0 +1,129 @@
+from datetime import date
+from uuid import uuid4
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from morva.masterdata.authoritative import validate_authoritative_master_data
+from morva.persistence.domain_extensions import AssignmentRecord
+from morva.persistence.enterprise_models import OrganizationUnitRecord
+from morva.persistence.masterdata_records import PositionRecord
+from morva.persistence.models import Base, EmployeeRecord
+
+
+def _session():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)()
+
+
+def _employee(session, *, employee_no: str, org, position):
+    session.add(
+        EmployeeRecord(
+            employee_no=employee_no,
+            source_employee_key="SRC-" + employee_no,
+            national_id=str(uuid4().int)[-10:],
+            first_name="Authoritative",
+            last_name="Test",
+            employment_type="permanent",
+            status="active",
+            organization_unit_id=str(org.id),
+            position_id=position.code,
+            hire_date=date(2020, 1, 1),
+        )
+    )
+
+
+def test_authoritative_gate_accepts_non_overlapping_assignments():
+    with _session() as session:
+        org = OrganizationUnitRecord(code="ORG-1", name="Org", kind="district")
+        position = PositionRecord(code="POS-1", title="Position", occupational_group="education")
+        session.add_all([org, position])
+        session.flush()
+        employee_no = "EMP-1"
+        _employee(session, employee_no=employee_no, org=org, position=position)
+        session.add_all(
+            [
+                AssignmentRecord(
+                    employee_no=employee_no,
+                    organization_code=org.code,
+                    position_code=position.code,
+                    starts_on=date(2026, 1, 1),
+                    ends_on=date(2026, 3, 31),
+                ),
+                AssignmentRecord(
+                    employee_no=employee_no,
+                    organization_code=org.code,
+                    position_code=position.code,
+                    starts_on=date(2026, 4, 1),
+                ),
+            ]
+        )
+        session.commit()
+        result = validate_authoritative_master_data(session)
+        assert result.blocking is False
+        assert result.findings == ()
+
+
+def test_authoritative_gate_blocks_overlapping_assignments():
+    with _session() as session:
+        org = OrganizationUnitRecord(code="ORG-2", name="Org", kind="district")
+        position = PositionRecord(code="POS-2", title="Position", occupational_group="education")
+        session.add_all([org, position])
+        session.flush()
+        employee_no = "EMP-2"
+        _employee(session, employee_no=employee_no, org=org, position=position)
+        session.add_all(
+            [
+                AssignmentRecord(
+                    employee_no=employee_no,
+                    organization_code=org.code,
+                    position_code=position.code,
+                    starts_on=date(2026, 1, 1),
+                    ends_on=date(2026, 6, 30),
+                ),
+                AssignmentRecord(
+                    employee_no=employee_no,
+                    organization_code=org.code,
+                    position_code=position.code,
+                    starts_on=date(2026, 6, 15),
+                    ends_on=date(2026, 12, 31),
+                ),
+            ]
+        )
+        session.commit()
+        result = validate_authoritative_master_data(session)
+        assert result.blocking is True
+        assert any(item.code == "ASSIGNMENT_OVERLAP" for item in result.findings)
+
+
+def test_authoritative_gate_blocks_active_employee_without_assignment():
+    with _session() as session:
+        org = OrganizationUnitRecord(code="ORG-3", name="Org", kind="district")
+        position = PositionRecord(code="POS-3", title="Position", occupational_group="education")
+        session.add_all([org, position])
+        session.flush()
+        _employee(session, employee_no="EMP-3", org=org, position=position)
+        session.commit()
+        result = validate_authoritative_master_data(session)
+        assert result.blocking is True
+        assert any(item.code == "ACTIVE_EMPLOYEE_NO_ASSIGNMENT" for item in result.findings)
+
+
+def test_authoritative_gate_blocks_invalid_position_effective_range():
+    with _session() as session:
+        org = OrganizationUnitRecord(code="ORG-4", name="Org", kind="district")
+        position = PositionRecord(
+            code="POS-4",
+            title="Position",
+            occupational_group="education",
+            effective_from=date(2026, 6, 1),
+            effective_to=date(2026, 5, 31),
+        )
+        session.add_all([org, position])
+        session.flush()
+        _employee(session, employee_no="EMP-4", org=org, position=position)
+        session.commit()
+        result = validate_authoritative_master_data(session)
+        assert result.blocking is True
+        assert any(item.code == "POSITION_INVALID_RANGE" for item in result.findings)


### PR DESCRIPTION
M3.1 starts the authoritative master-data tranche by adding a fail-closed integrity gate over effective-dated positions, non-overlapping personnel assignments, and active employees requiring assignment. Includes deterministic regression coverage. No legal rates or payroll treatments are introduced.