### PR TITLE
feat: M3.3 teacher rank case lifecycle

### DIFF
--- a/src/morva/api/app.py
+++ b/src/morva/api/app.py
@@ -15,6 +15,7 @@ from morva.api.v1.payroll import router as payroll_router
 from morva.api.v1.reconciliation import router as reconciliation_router
 from morva.api.v1.rule_governance import router as rule_governance_router
 from morva.api.v1.rules import router as rules_router
+from morva.api.v1.teacher_rank import router as teacher_rank_router
 from morva.api.v1.validation import router as validation_router
 from morva.persistence.database import init_db
 from morva.runtime.config import settings
@@ -44,6 +45,7 @@ app.include_router(masterdata_acceptance_router, prefix="/api/v1", dependencies=
 app.include_router(order_approvals_router, prefix="/api/v1", dependencies=protected_dependencies)
 app.include_router(rule_governance_router, prefix="/api/v1", dependencies=protected_dependencies)
 app.include_router(assignment_attendance_router, prefix="/api/v1", dependencies=protected_dependencies)
+app.include_router(teacher_rank_router, prefix="/api/v1", dependencies=protected_dependencies)
 
 
 @app.get("/health", tags=["system"])

--- a/src/morva/api/v1/teacher_rank.py
+++ b/src/morva/api/v1/teacher_rank.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from morva.hr.teacher_rank import approve_committee, create_rank_case, decide_case, open_appeal, resolve_appeal, submit_assessment
+from morva.persistence.database import SessionLocal
+from morva.persistence.domain_extensions import TeacherRankCaseRecord
+from morva.persistence.models import EmployeeRecord
+from morva.security.auth import Principal, get_current_principal
+from morva.security.hierarchy import authorize_hierarchical
+
+router = APIRouter(prefix="/hr", tags=["teacher-rank"])
+
+
+class RankCaseInput(BaseModel):
+    proposed_rank: str = Field(min_length=1, max_length=50)
+    current_rank: str | None = Field(default=None, max_length=50)
+    effect_period: str = Field(pattern=r"^\d{4}-\d{2}$")
+    assessment: dict = Field(default_factory=dict)
+
+
+class EvidenceInput(BaseModel):
+    evidence: dict
+
+
+class CommitteeInput(BaseModel):
+    evidence: dict
+    reviewer_id: str = Field(min_length=1)
+
+
+class DecisionInput(BaseModel):
+    decision_reference: str = Field(min_length=1, max_length=150)
+
+
+class AppealInput(BaseModel):
+    appeal: dict
+
+
+class AppealResolutionInput(BaseModel):
+    resolution: dict
+    reviewer_id: str = Field(min_length=1)
+
+
+def _employee(session, employee_no: str) -> EmployeeRecord:
+    employee = session.scalar(select(EmployeeRecord).where(EmployeeRecord.employee_no == employee_no))
+    if employee is None:
+        raise HTTPException(status_code=404, detail="employee not found")
+    return employee
+
+
+def _case_payload(record: TeacherRankCaseRecord) -> dict[str, object]:
+    return {
+        "id": str(record.id),
+        "employee_no": record.employee_no,
+        "current_rank": record.current_rank,
+        "proposed_rank": record.proposed_rank,
+        "status": record.status,
+        "effect_period": record.effect_period,
+        "assessment": record.assessment_payload,
+        "committee": record.committee_payload,
+        "appeal": record.appeal_payload,
+        "decision_reference": record.decision_reference,
+    }
+
+
+def _get_case(session, case_id: UUID) -> TeacherRankCaseRecord:
+    record = session.get(TeacherRankCaseRecord, case_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="teacher rank case not found")
+    return record
+
+
+def _authorize(session, principal: Principal, employee: EmployeeRecord, permission: str) -> None:
+    authorize_hierarchical(session, principal, permission, employee.organization_unit_id)
+
+
+@router.post("/employees/{employee_no}/teacher-rank-cases", status_code=201)
+def create_case(employee_no: str, payload: RankCaseInput, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
+    with SessionLocal() as session:
+        employee = _employee(session, employee_no)
+        _authorize(session, principal, employee, "personnel.write")
+        try:
+            result = create_rank_case(session, employee_no=employee_no, proposed_rank=payload.proposed_rank, current_rank=payload.current_rank, effect_period=payload.effect_period, assessment_payload=payload.assessment, actor_id=principal.user_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        session.commit()
+        return {"status": result.status, "case_id": str(result.case_id)}
+
+
+@router.get("/employees/{employee_no}/teacher-rank-cases")
+def list_cases(employee_no: str, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
+    with SessionLocal() as session:
+        employee = _employee(session, employee_no)
+        _authorize(session, principal, employee, "personnel.read")
+        records = session.scalars(select(TeacherRankCaseRecord).where(TeacherRankCaseRecord.employee_no == employee_no).order_by(TeacherRankCaseRecord.effect_period.desc(), TeacherRankCaseRecord.created_at.desc())).all()
+        return {"employee_no": employee_no, "items": [_case_payload(record) for record in records]}
+
+
+@router.get("/teacher-rank-cases/{case_id}")
+def get_case(case_id: UUID, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
+    with SessionLocal() as session:
+        record = _get_case(session, case_id)
+        employee = _employee(session, record.employee_no)
+        _authorize(session, principal, employee, "personnel.read")
+        return _case_payload(record)
+
+
+@router.post("/teacher-rank-cases/{case_id}/assessment")
+def assess_case(case_id: UUID, payload: EvidenceInput, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
+    with SessionLocal() as session:
+        record = _get_case(session, case_id)
+        employee = _employee(session, record.employee_no)
+        _authorize(session, principal, employee, "personnel.review")
+        try:
+            result = submit_assessment(session, case_id, principal.user_id, payload.evidence)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        session.commit()
+        return {"status": result.status, "case_id": str(result.case_id)}
+
+
+@router.post("/teacher-rank-cases/{case_id}/committee-approval")
+def committee_approval(case_id: UUID, payload: CommitteeInput, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
+    with SessionLocal() as session:
+        record = _get_case(session, case_id)
+        employee = _employee(session, record.employee_no)
+        _authorize(session, principal, employee, "personnel.approve")
+        try:
+            result = approve_committee(session, case_id, principal.user_id, payload.evidence, payload.reviewer_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        session.commit()
+        return {"status": result.status, "case_id": str(result.case_id)}
+
+
+@router.post("/teacher-rank-cases/{case_id}/decision")
+def decide(case_id: UUID, payload: DecisionInput, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
+    with SessionLocal() as session:
+        record = _get_case(session, case_id)
+        employee = _employee(session, record.employee_no)
+        _authorize(session, principal, employee, "personnel.approve")
+        try:
+            result = decide_case(session, case_id, principal.user_id, payload.decision_reference)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        session.commit()
+        return {"status": result.status, "case_id": str(result.case_id)}
+
+
+@router.post("/teacher-rank-cases/{case_id}/appeal")
+def appeal(case_id: UUID, payload: AppealInput, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
+    with SessionLocal() as session:
+        record = _get_case(session, case_id)
+        employee = _employee(session, record.employee_no)
+        _authorize(session, principal, employee, "personnel.write")
+        try:
+            result = open_appeal(session, case_id, principal.user_id, payload.appeal)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        session.commit()
+        return {"status": result.status, "case_id": str(result.case_id)}
+
+
+@router.post("/teacher-rank-cases/{case_id}/appeal-resolution")
+def appeal_resolution(case_id: UUID, payload: AppealResolutionInput, principal: Principal = Depends(get_current_principal)) -> dict[str, object]:
+    with SessionLocal() as session:
+        record = _get_case(session, case_id)
+        employee = _employee(session, record.employee_no)
+        _authorize(session, principal, employee, "personnel.approve")
+        try:
+            result = resolve_appeal(session, case_id, principal.user_id, payload.resolution, payload.reviewer_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        session.commit()
+        return {"status": result.status, "case_id": str(result.case_id)}

--- a/src/morva/hr/teacher_rank.py
+++ b/src/morva/hr/teacher_rank.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from morva.audit.persistence import append_audit_event
+from morva.persistence.domain_extensions import TeacherRankCaseRecord
+from morva.persistence.models import EmployeeRecord
+from morva.security.policy import require_distinct_actors
+
+_ALLOWED_TRANSITIONS = {"draft": {"assessed"}, "assessed": {"committee_approved"}, "committee_approved": {"decided"}, "decided": {"appeal_opened"}, "appeal_opened": {"appeal_resolved"}, "appeal_resolved": set()}
+
+@dataclass(frozen=True, slots=True)
+class RankCaseResult:
+    case_id: UUID
+    status: str
+
+def _case(session: Session, case_id: UUID) -> TeacherRankCaseRecord:
+    record = session.get(TeacherRankCaseRecord, case_id)
+    if record is None:
+        raise ValueError("teacher rank case not found")
+    return record
+
+def _employee(session: Session, employee_no: str) -> EmployeeRecord:
+    employee = session.scalar(select(EmployeeRecord).where(EmployeeRecord.employee_no == employee_no))
+    if employee is None:
+        raise ValueError("employee not found")
+    return employee
+
+def _transition(session: Session, record: TeacherRankCaseRecord, *, target: str, actor_id: str, reason: str, reviewer_id: str | None = None) -> RankCaseResult:
+    if target not in _ALLOWED_TRANSITIONS.get(record.status, set()):
+        raise ValueError(f"invalid teacher rank transition: {record.status} -> {target}")
+    if reviewer_id is not None:
+        require_distinct_actors(actor_id, reviewer_id)
+    record.status = target
+    append_audit_event(event_type=f"hr.teacher_rank.{target}", entity_type="teacher_rank_case", entity_id=str(record.id), actor_id=actor_id, payload={"employee_no": record.employee_no, "proposed_rank": record.proposed_rank}, reason=reason, session=session)
+    return RankCaseResult(case_id=record.id, status=record.status)
+
+def create_rank_case(session: Session, *, employee_no: str, proposed_rank: str, effect_period: str, actor_id: str, current_rank: str | None = None, assessment_payload: dict | None = None) -> RankCaseResult:
+    _employee(session, employee_no)
+    if not proposed_rank.strip():
+        raise ValueError("proposed_rank is required")
+    if len(effect_period) != 7 or effect_period[4] != "-":
+        raise ValueError("effect_period must use YYYY-MM")
+    duplicate = session.scalar(select(TeacherRankCaseRecord).where(TeacherRankCaseRecord.employee_no == employee_no, TeacherRankCaseRecord.effect_period == effect_period, TeacherRankCaseRecord.proposed_rank == proposed_rank))
+    if duplicate is not None:
+        return RankCaseResult(case_id=duplicate.id, status=duplicate.status)
+    record = TeacherRankCaseRecord(employee_no=employee_no, current_rank=current_rank, proposed_rank=proposed_rank, status="draft", effect_period=effect_period, assessment_payload=assessment_payload or {}, committee_payload={}, appeal_payload={})
+    session.add(record)
+    session.flush()
+    append_audit_event(event_type="hr.teacher_rank.created", entity_type="teacher_rank_case", entity_id=str(record.id), actor_id=actor_id, payload={"employee_no": employee_no, "effect_period": effect_period, "proposed_rank": proposed_rank}, reason="register teacher rank case", session=session)
+    return RankCaseResult(case_id=record.id, status=record.status)
+
+def submit_assessment(session: Session, case_id: UUID, actor_id: str, assessment: dict) -> RankCaseResult:
+    if not assessment:
+        raise ValueError("assessment evidence is required")
+    record = _case(session, case_id)
+    record.assessment_payload = assessment
+    return _transition(session, record, target="assessed", actor_id=actor_id, reason="submit rank assessment evidence")
+
+def approve_committee(session: Session, case_id: UUID, actor_id: str, committee: dict, reviewer_id: str) -> RankCaseResult:
+    if not committee:
+        raise ValueError("committee evidence is required")
+    record = _case(session, case_id)
+    record.committee_payload = committee
+    return _transition(session, record, target="committee_approved", actor_id=actor_id, reviewer_id=reviewer_id, reason="approve rank committee evidence")
+
+def decide_case(session: Session, case_id: UUID, actor_id: str, decision_reference: str) -> RankCaseResult:
+    if not decision_reference.strip():
+        raise ValueError("decision_reference is required")
+    record = _case(session, case_id)
+    record.decision_reference = decision_reference
+    return _transition(session, record, target="decided", actor_id=actor_id, reason="record authoritative rank decision")
+
+def open_appeal(session: Session, case_id: UUID, actor_id: str, appeal: dict) -> RankCaseResult:
+    if not appeal:
+        raise ValueError("appeal payload is required")
+    record = _case(session, case_id)
+    record.appeal_payload = {**record.appeal_payload, "opened": appeal}
+    return _transition(session, record, target="appeal_opened", actor_id=actor_id, reason="open teacher rank appeal")
+
+def resolve_appeal(session: Session, case_id: UUID, actor_id: str, resolution: dict, reviewer_id: str) -> RankCaseResult:
+    if not resolution:
+        raise ValueError("appeal resolution is required")
+    record = _case(session, case_id)
+    record.appeal_payload = {**record.appeal_payload, "resolution": resolution}
+    return _transition(session, record, target="appeal_resolved", actor_id=actor_id, reviewer_id=reviewer_id, reason="resolve teacher rank appeal")


### PR DESCRIPTION
Implements the next M3 tranche as a fail-closed teacher rank workflow foundation:

- teacher rank case lifecycle: draft -> assessed -> committee_approved -> decided
- appeal lifecycle with immutable terminal resolution state
- evidence required before assessment/committee/decision transitions
- separation-of-duties enforcement for committee approval and appeal resolution
- authenticated, hierarchical APIs for create/read and lifecycle transitions
- lifecycle audit events for every state transition
- deterministic case idempotency at employee/effective-period/proposed-rank boundary

This tranche does not invent legal rank values, ministry rank data, or statutory treatments. Authoritative rank catalog/source evidence remains a production admission requirement.