### PR TITLE
feat: M3.4 authoritative teacher rank evidence gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,19 @@ jobs:
       - run: ruff check src/morva/masterdata src/morva/personnel src/morva/api/v1/assignment_attendance.py tests/test_m3_2_assignment_attendance.py
       - run: pytest -q tests/test_masterdata_validation.py tests/test_masterdata_acceptance.py tests/test_m3_2_assignment_attendance.py
 
+  m3-4-gate:
+    name: M3.4 teacher rank evidence gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff check src/morva/hr/teacher_rank.py src/morva/hr/teacher_rank_evidence.py tests/test_teacher_rank_evidence.py
+      - run: pytest -q tests/test_teacher_rank_evidence.py
+
   web-build:
     runs-on: ubuntu-latest
     defaults:

--- a/src/morva/hr/teacher_rank.py
+++ b/src/morva/hr/teacher_rank.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from morva.audit.persistence import append_audit_event
+from morva.hr.teacher_rank_evidence import check_teacher_rank_evidence
 from morva.persistence.domain_extensions import TeacherRankCaseRecord
 from morva.persistence.models import EmployeeRecord
 from morva.security.policy import require_distinct_actors
@@ -72,6 +73,9 @@ def decide_case(session: Session, case_id: UUID, actor_id: str, decision_referen
     if not decision_reference.strip():
         raise ValueError("decision_reference is required")
     record = _case(session, case_id)
+    evidence_gate = check_teacher_rank_evidence(session, record)
+    if not evidence_gate.ready:
+        raise ValueError("teacher rank decision blocked by authoritative evidence gate: " + "; ".join(evidence_gate.blockers))
     record.decision_reference = decision_reference
     return _transition(session, record, target="decided", actor_id=actor_id, reason="record authoritative rank decision")
 

--- a/src/morva/hr/teacher_rank_evidence.py
+++ b/src/morva/hr/teacher_rank_evidence.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from morva.persistence.domain_extensions import TeacherRankCaseRecord
+from morva.persistence.enterprise_models import LegalSourceRecord, RuleEvidenceRecord
+
+_HEX64 = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+@dataclass(frozen=True, slots=True)
+class TeacherRankEvidenceResult:
+    ready: bool
+    blockers: tuple[str, ...]
+    legal_source_id: UUID | None = None
+    evidence_id: UUID | None = None
+
+
+def _parse_period(value: str) -> date | None:
+    if not re.fullmatch(r"\d{4}-\d{2}", value):
+        return None
+    year, month = (int(part) for part in value.split("-"))
+    if not 1 <= month <= 12:
+        return None
+    return date(year, month, 1)
+
+
+def check_teacher_rank_evidence(
+    session: Session,
+    case: TeacherRankCaseRecord,
+) -> TeacherRankEvidenceResult:
+    blockers: list[str] = []
+    effect_period = _parse_period(case.effect_period)
+    if effect_period is None:
+        blockers.append("teacher rank effect_period must use YYYY-MM")
+
+    component_code = f"teacher_rank:{case.proposed_rank.strip()}"
+    candidates = session.scalars(
+        select(RuleEvidenceRecord)
+        .where(RuleEvidenceRecord.component_code == component_code)
+        .order_by(RuleEvidenceRecord.approved_at.desc(), RuleEvidenceRecord.id)
+    ).all()
+    if not candidates:
+        return TeacherRankEvidenceResult(
+            ready=False,
+            blockers=(f"no approved evidence is registered for {component_code}",),
+        )
+
+    for evidence in candidates:
+        source = session.get(LegalSourceRecord, evidence.legal_source_id)
+        candidate_blockers: list[str] = []
+        if source is None:
+            candidate_blockers.append("legal source is missing")
+        else:
+            if source.status != "approved":
+                candidate_blockers.append("legal source is not approved")
+            if evidence.source_hash != source.document_hash:
+                candidate_blockers.append("evidence source hash does not match legal source")
+            try:
+                source_from = date.fromisoformat(source.effective_from)
+                source_to = date.fromisoformat(source.effective_to) if source.effective_to else None
+            except ValueError:
+                candidate_blockers.append("legal source has invalid effective dates")
+            else:
+                if source_to is not None and source_to < source_from:
+                    candidate_blockers.append("legal source effective_to precedes effective_from")
+                if effect_period is not None and effect_period < source_from:
+                    candidate_blockers.append("teacher rank effect period predates legal source")
+                if effect_period is not None and source_to is not None and effect_period > source_to:
+                    candidate_blockers.append("teacher rank effect period exceeds legal source")
+
+        if evidence.status != "approved":
+            candidate_blockers.append("teacher rank evidence is not approved")
+        if not evidence.article.strip():
+            candidate_blockers.append("teacher rank evidence article is missing")
+        if not evidence.population_scope.strip():
+            candidate_blockers.append("teacher rank evidence population scope is missing")
+        if not _HEX64.fullmatch(evidence.source_hash):
+            candidate_blockers.append("teacher rank evidence source hash is invalid")
+        if not _HEX64.fullmatch(evidence.regression_suite_hash):
+            candidate_blockers.append("teacher rank evidence regression suite hash is invalid")
+        if evidence.reviewed_by and evidence.approved_by and evidence.reviewed_by == evidence.approved_by:
+            candidate_blockers.append("teacher rank evidence reviewer and approver must be distinct")
+
+        if not candidate_blockers and source is not None:
+            return TeacherRankEvidenceResult(
+                ready=True,
+                blockers=(),
+                legal_source_id=source.id,
+                evidence_id=evidence.id,
+            )
+
+        blockers.extend(f"{component_code}: {reason}" for reason in candidate_blockers)
+
+    return TeacherRankEvidenceResult(ready=False, blockers=tuple(dict.fromkeys(blockers)))

--- a/src/morva/hr/teacher_rank_evidence.py
+++ b/src/morva/hr/teacher_rank_evidence.py
@@ -60,6 +60,8 @@ def check_teacher_rank_evidence(
         else:
             if source.status != "approved":
                 candidate_blockers.append("legal source is not approved")
+            if not _HEX64.fullmatch(source.document_hash):
+                candidate_blockers.append("legal source document hash is invalid")
             if evidence.source_hash != source.document_hash:
                 candidate_blockers.append("evidence source hash does not match legal source")
             try:

--- a/tests/test_teacher_rank_evidence.py
+++ b/tests/test_teacher_rank_evidence.py
@@ -1,0 +1,137 @@
+from uuid import uuid4
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from morva.hr.teacher_rank_evidence import check_teacher_rank_evidence
+from morva.persistence.domain_extensions import TeacherRankCaseRecord
+from morva.persistence.enterprise_models import Base, LegalSourceRecord, RuleEvidenceRecord
+
+_HASH = "a" * 64
+_REGRESSION = "b" * 64
+
+
+def _case(effect_period: str = "1405-06", proposed_rank: str = "rank-A") -> TeacherRankCaseRecord:
+    return TeacherRankCaseRecord(
+        employee_no="E-1",
+        current_rank="rank-0",
+        proposed_rank=proposed_rank,
+        status="committee_approved",
+        effect_period=effect_period,
+        assessment_payload={},
+        committee_payload={},
+        appeal_payload={},
+    )
+
+
+def _source(*, source_hash: str = _HASH, status: str = "approved", effective_from: str = "1405-01-01", effective_to: str | None = None) -> LegalSourceRecord:
+    return LegalSourceRecord(
+        citation="authoritative-test-source",
+        issuer="test-authority",
+        adoption_date="1404-12-01",
+        effective_from=effective_from,
+        effective_to=effective_to,
+        document_hash=source_hash,
+        source_uri="https://example.invalid/source",
+        status=status,
+    )
+
+
+def _evidence(source_id, *, status: str = "approved", source_hash: str = _HASH, reviewer: str = "reviewer", approver: str = "approver") -> RuleEvidenceRecord:
+    return RuleEvidenceRecord(
+        rule_pack_version="teacher-rank-test-1",
+        component_code="teacher_rank:rank-A",
+        legal_source_id=source_id,
+        issuer="test-authority",
+        article="article-1",
+        clause=None,
+        population_scope="teacher-rank-population",
+        source_hash=source_hash,
+        regression_suite_hash=_REGRESSION,
+        status=status,
+        reviewed_by=reviewer,
+        approved_by=approver,
+    )
+
+
+def test_missing_evidence_fails_closed() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        result = check_teacher_rank_evidence(session, _case())
+        assert result.ready is False
+        assert "no approved evidence" in result.blockers[0]
+
+
+def test_approved_matching_source_and_evidence_is_ready() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        source = _source()
+        session.add(source)
+        session.flush()
+        evidence = _evidence(source.id)
+        session.add(evidence)
+        session.flush()
+        result = check_teacher_rank_evidence(session, _case())
+        assert result.ready is True
+        assert result.blockers == ()
+        assert result.legal_source_id == source.id
+        assert result.evidence_id == evidence.id
+
+
+def test_unapproved_source_and_evidence_block_decision() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        source = _source(status="reviewed")
+        session.add(source)
+        session.flush()
+        session.add(_evidence(source.id, status="reviewed"))
+        session.flush()
+        result = check_teacher_rank_evidence(session, _case())
+        assert result.ready is False
+        assert any("legal source is not approved" in blocker for blocker in result.blockers)
+        assert any("teacher rank evidence is not approved" in blocker for blocker in result.blockers)
+
+
+def test_hash_mismatch_blocks_even_when_records_are_approved() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        source = _source(source_hash="c" * 64)
+        session.add(source)
+        session.flush()
+        session.add(_evidence(source.id))
+        session.flush()
+        result = check_teacher_rank_evidence(session, _case())
+        assert result.ready is False
+        assert any("source hash does not match legal source" in blocker for blocker in result.blockers)
+
+
+def test_effect_period_outside_source_window_blocks() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        source = _source(effective_from="1405-07-01", effective_to="1405-12-29")
+        session.add(source)
+        session.flush()
+        session.add(_evidence(source.id))
+        session.flush()
+        result = check_teacher_rank_evidence(session, _case(effect_period="1405-06"))
+        assert result.ready is False
+        assert any("effect period predates legal source" in blocker for blocker in result.blockers)
+
+
+def test_invalid_hash_is_rejected() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        source = _source(source_hash="not-a-sha256")
+        session.add(source)
+        session.flush()
+        session.add(_evidence(source.id))
+        session.flush()
+        result = check_teacher_rank_evidence(session, _case())
+        assert result.ready is False
+        assert any("evidence source hash is invalid" in blocker for blocker in result.blockers)

--- a/tests/test_teacher_rank_evidence.py
+++ b/tests/test_teacher_rank_evidence.py
@@ -1,5 +1,3 @@
-from uuid import uuid4
-
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
@@ -54,19 +52,21 @@ def _evidence(source_id, *, status: str = "approved", source_hash: str = _HASH, 
     )
 
 
-def test_missing_evidence_fails_closed() -> None:
+def _session() -> Session:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
-    with Session(engine) as session:
+    return Session(engine)
+
+
+def test_missing_evidence_fails_closed() -> None:
+    with _session() as session:
         result = check_teacher_rank_evidence(session, _case())
         assert result.ready is False
         assert "no approved evidence" in result.blockers[0]
 
 
 def test_approved_matching_source_and_evidence_is_ready() -> None:
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
-    with Session(engine) as session:
+    with _session() as session:
         source = _source()
         session.add(source)
         session.flush()
@@ -81,9 +81,7 @@ def test_approved_matching_source_and_evidence_is_ready() -> None:
 
 
 def test_unapproved_source_and_evidence_block_decision() -> None:
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
-    with Session(engine) as session:
+    with _session() as session:
         source = _source(status="reviewed")
         session.add(source)
         session.flush()
@@ -96,9 +94,7 @@ def test_unapproved_source_and_evidence_block_decision() -> None:
 
 
 def test_hash_mismatch_blocks_even_when_records_are_approved() -> None:
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
-    with Session(engine) as session:
+    with _session() as session:
         source = _source(source_hash="c" * 64)
         session.add(source)
         session.flush()
@@ -110,9 +106,7 @@ def test_hash_mismatch_blocks_even_when_records_are_approved() -> None:
 
 
 def test_effect_period_outside_source_window_blocks() -> None:
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
-    with Session(engine) as session:
+    with _session() as session:
         source = _source(effective_from="1405-07-01", effective_to="1405-12-29")
         session.add(source)
         session.flush()
@@ -123,15 +117,14 @@ def test_effect_period_outside_source_window_blocks() -> None:
         assert any("effect period predates legal source" in blocker for blocker in result.blockers)
 
 
-def test_invalid_hash_is_rejected() -> None:
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
-    with Session(engine) as session:
+def test_invalid_source_hash_is_rejected() -> None:
+    with _session() as session:
         source = _source(source_hash="not-a-sha256")
         session.add(source)
         session.flush()
-        session.add(_evidence(source.id))
+        session.add(_evidence(source.id, source_hash="not-a-sha256"))
         session.flush()
         result = check_teacher_rank_evidence(session, _case())
         assert result.ready is False
-        assert any("evidence source hash is invalid" in blocker for blocker in result.blockers)
+        assert any("legal source document hash is invalid" in blocker for blocker in result.blockers)
+        assert any("teacher rank evidence source hash is invalid" in blocker for blocker in result.blockers)


### PR DESCRIPTION
Implements the M3.4 fail-closed evidence gate for teacher-rank decisions. Decision transition now requires approved legal source and approved evidence, matching SHA-256 provenance, valid source dates, in-range effect period, population/article coverage, valid regression hash, and distinct reviewer/approver. Adds focused regression tests for missing, unapproved, mismatched, out-of-window, and invalid-hash cases.

No legal rank values or authoritative rates are invented by this change.