### PR TITLE
feat: M3.5 teacher rank decision SoD hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,19 @@ jobs:
       - run: ruff check src/morva/hr/teacher_rank.py src/morva/hr/teacher_rank_evidence.py tests/test_teacher_rank_evidence.py
       - run: pytest -q tests/test_teacher_rank_evidence.py
 
+  m3-5-gate:
+    name: M3.5 teacher rank decision SoD gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff check src/morva/hr/teacher_rank.py tests/test_teacher_rank_decision_sod.py
+      - run: pytest -q tests/test_teacher_rank_decision_sod.py
+
   web-build:
     runs-on: ubuntu-latest
     defaults:

--- a/docs/M3_5_DECISION_SOD.md
+++ b/docs/M3_5_DECISION_SOD.md
@@ -1,0 +1,15 @@
+# M3.5 — Teacher Rank Decision SoD
+
+## Scope
+
+This tranche hardens the teacher-rank decision transition without introducing any legal rank values or statutory treatment.
+
+## Invariants
+
+A final teacher-rank decision is fail-closed unless committee approval provenance exists and records distinct committee approver, committee reviewer and final decision actor identities.
+
+Committee approval stores governance provenance alongside the submitted committee evidence. Existing `require_distinct_actors` policy enforcement is reused for all pairwise actor separation required by this gate.
+
+## Production posture
+
+This is an authorization and provenance control only. It does not certify legal sources, rank catalogs, payroll coefficients or payment integrations.

--- a/src/morva/hr/teacher_rank.py
+++ b/src/morva/hr/teacher_rank.py
@@ -14,10 +14,26 @@ from morva.security.policy import require_distinct_actors
 
 _ALLOWED_TRANSITIONS = {"draft": {"assessed"}, "assessed": {"committee_approved"}, "committee_approved": {"decided"}, "decided": {"appeal_opened"}, "appeal_opened": {"appeal_resolved"}, "appeal_resolved": set()}
 
+
 @dataclass(frozen=True, slots=True)
 class RankCaseResult:
     case_id: UUID
     status: str
+
+
+def check_decision_separation_of_duties(record: TeacherRankCaseRecord, actor_id: str) -> None:
+    governance = record.committee_payload.get("_governance") if isinstance(record.committee_payload, dict) else None
+    if not isinstance(governance, dict):
+        raise ValueError("teacher rank decision blocked: committee approval provenance is missing")
+    approver_id = governance.get("actor_id")
+    reviewer_id = governance.get("reviewer_id")
+    if not isinstance(approver_id, str) or not approver_id.strip():
+        raise ValueError("teacher rank decision blocked: committee approver provenance is missing")
+    if not isinstance(reviewer_id, str) or not reviewer_id.strip():
+        raise ValueError("teacher rank decision blocked: committee reviewer provenance is missing")
+    require_distinct_actors(approver_id, reviewer_id)
+    require_distinct_actors(approver_id, actor_id)
+
 
 def _case(session: Session, case_id: UUID) -> TeacherRankCaseRecord:
     record = session.get(TeacherRankCaseRecord, case_id)
@@ -25,11 +41,13 @@ def _case(session: Session, case_id: UUID) -> TeacherRankCaseRecord:
         raise ValueError("teacher rank case not found")
     return record
 
+
 def _employee(session: Session, employee_no: str) -> EmployeeRecord:
     employee = session.scalar(select(EmployeeRecord).where(EmployeeRecord.employee_no == employee_no))
     if employee is None:
         raise ValueError("employee not found")
     return employee
+
 
 def _transition(session: Session, record: TeacherRankCaseRecord, *, target: str, actor_id: str, reason: str, reviewer_id: str | None = None) -> RankCaseResult:
     if target not in _ALLOWED_TRANSITIONS.get(record.status, set()):
@@ -39,6 +57,7 @@ def _transition(session: Session, record: TeacherRankCaseRecord, *, target: str,
     record.status = target
     append_audit_event(event_type=f"hr.teacher_rank.{target}", entity_type="teacher_rank_case", entity_id=str(record.id), actor_id=actor_id, payload={"employee_no": record.employee_no, "proposed_rank": record.proposed_rank}, reason=reason, session=session)
     return RankCaseResult(case_id=record.id, status=record.status)
+
 
 def create_rank_case(session: Session, *, employee_no: str, proposed_rank: str, effect_period: str, actor_id: str, current_rank: str | None = None, assessment_payload: dict | None = None) -> RankCaseResult:
     _employee(session, employee_no)
@@ -55,6 +74,7 @@ def create_rank_case(session: Session, *, employee_no: str, proposed_rank: str, 
     append_audit_event(event_type="hr.teacher_rank.created", entity_type="teacher_rank_case", entity_id=str(record.id), actor_id=actor_id, payload={"employee_no": employee_no, "effect_period": effect_period, "proposed_rank": proposed_rank}, reason="register teacher rank case", session=session)
     return RankCaseResult(case_id=record.id, status=record.status)
 
+
 def submit_assessment(session: Session, case_id: UUID, actor_id: str, assessment: dict) -> RankCaseResult:
     if not assessment:
         raise ValueError("assessment evidence is required")
@@ -62,12 +82,15 @@ def submit_assessment(session: Session, case_id: UUID, actor_id: str, assessment
     record.assessment_payload = assessment
     return _transition(session, record, target="assessed", actor_id=actor_id, reason="submit rank assessment evidence")
 
+
 def approve_committee(session: Session, case_id: UUID, actor_id: str, committee: dict, reviewer_id: str) -> RankCaseResult:
     if not committee:
         raise ValueError("committee evidence is required")
     record = _case(session, case_id)
-    record.committee_payload = committee
+    require_distinct_actors(actor_id, reviewer_id)
+    record.committee_payload = {**committee, "_governance": {"actor_id": actor_id, "reviewer_id": reviewer_id}}
     return _transition(session, record, target="committee_approved", actor_id=actor_id, reviewer_id=reviewer_id, reason="approve rank committee evidence")
+
 
 def decide_case(session: Session, case_id: UUID, actor_id: str, decision_reference: str) -> RankCaseResult:
     if not decision_reference.strip():
@@ -76,8 +99,10 @@ def decide_case(session: Session, case_id: UUID, actor_id: str, decision_referen
     evidence_gate = check_teacher_rank_evidence(session, record)
     if not evidence_gate.ready:
         raise ValueError("teacher rank decision blocked by authoritative evidence gate: " + "; ".join(evidence_gate.blockers))
+    check_decision_separation_of_duties(record, actor_id)
     record.decision_reference = decision_reference
     return _transition(session, record, target="decided", actor_id=actor_id, reason="record authoritative rank decision")
+
 
 def open_appeal(session: Session, case_id: UUID, actor_id: str, appeal: dict) -> RankCaseResult:
     if not appeal:
@@ -85,6 +110,7 @@ def open_appeal(session: Session, case_id: UUID, actor_id: str, appeal: dict) ->
     record = _case(session, case_id)
     record.appeal_payload = {**record.appeal_payload, "opened": appeal}
     return _transition(session, record, target="appeal_opened", actor_id=actor_id, reason="open teacher rank appeal")
+
 
 def resolve_appeal(session: Session, case_id: UUID, actor_id: str, resolution: dict, reviewer_id: str) -> RankCaseResult:
     if not resolution:

--- a/src/morva/hr/teacher_rank.py
+++ b/src/morva/hr/teacher_rank.py
@@ -1,4 +1,4 @@
-from __future__
+from __future__ import annotations
 
 from dataclasses import dataclass
 from uuid import UUID

--- a/src/morva/hr/teacher_rank.py
+++ b/src/morva/hr/teacher_rank.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__
 
 from dataclasses import dataclass
 from uuid import UUID
@@ -31,8 +31,8 @@ def check_decision_separation_of_duties(record: TeacherRankCaseRecord, actor_id:
         raise ValueError("teacher rank decision blocked: committee approver provenance is missing")
     if not isinstance(reviewer_id, str) or not reviewer_id.strip():
         raise ValueError("teacher rank decision blocked: committee reviewer provenance is missing")
-    require_distinct_actors(approver_id, reviewer_id)
-    require_distinct_actors(approver_id, actor_id)
+    require_distinct_actors([approver_id, reviewer_id])
+    require_distinct_actors([approver_id, actor_id])
 
 
 def _case(session: Session, case_id: UUID) -> TeacherRankCaseRecord:
@@ -53,7 +53,7 @@ def _transition(session: Session, record: TeacherRankCaseRecord, *, target: str,
     if target not in _ALLOWED_TRANSITIONS.get(record.status, set()):
         raise ValueError(f"invalid teacher rank transition: {record.status} -> {target}")
     if reviewer_id is not None:
-        require_distinct_actors(actor_id, reviewer_id)
+        require_distinct_actors([actor_id, reviewer_id])
     record.status = target
     append_audit_event(event_type=f"hr.teacher_rank.{target}", entity_type="teacher_rank_case", entity_id=str(record.id), actor_id=actor_id, payload={"employee_no": record.employee_no, "proposed_rank": record.proposed_rank}, reason=reason, session=session)
     return RankCaseResult(case_id=record.id, status=record.status)
@@ -87,7 +87,7 @@ def approve_committee(session: Session, case_id: UUID, actor_id: str, committee:
     if not committee:
         raise ValueError("committee evidence is required")
     record = _case(session, case_id)
-    require_distinct_actors(actor_id, reviewer_id)
+    require_distinct_actors([actor_id, reviewer_id])
     record.committee_payload = {**committee, "_governance": {"actor_id": actor_id, "reviewer_id": reviewer_id}}
     return _transition(session, record, target="committee_approved", actor_id=actor_id, reviewer_id=reviewer_id, reason="approve rank committee evidence")
 

--- a/tests/test_teacher_rank_decision_sod.py
+++ b/tests/test_teacher_rank_decision_sod.py
@@ -1,0 +1,40 @@
+import pytest
+
+from morva.hr.teacher_rank import check_decision_separation_of_duties
+from morva.persistence.domain_extensions import TeacherRankCaseRecord
+
+
+def _case(**governance: str) -> TeacherRankCaseRecord:
+    return TeacherRankCaseRecord(
+        employee_no="E-1",
+        current_rank="rank-0",
+        proposed_rank="rank-A",
+        status="committee_approved",
+        effect_period="1405-06",
+        assessment_payload={},
+        committee_payload={"evidence": "approved", "_governance": governance},
+        appeal_payload={},
+    )
+
+
+def test_decision_requires_committee_provenance() -> None:
+    record = _case()
+    with pytest.raises(ValueError, match="committee approval provenance is missing"):
+        check_decision_separation_of_duties(record, "decision-maker")
+
+
+def test_decision_requires_distinct_committee_approver_and_reviewer() -> None:
+    record = _case(actor_id="reviewer", reviewer_id="reviewer")
+    with pytest.raises(ValueError):
+        check_decision_separation_of_duties(record, "decision-maker")
+
+
+def test_decision_maker_must_differ_from_committee_approver() -> None:
+    record = _case(actor_id="approver", reviewer_id="reviewer")
+    with pytest.raises(ValueError):
+        check_decision_separation_of_duties(record, "approver")
+
+
+def test_distinct_decision_actor_passes() -> None:
+    record = _case(actor_id="approver", reviewer_id="reviewer")
+    check_decision_separation_of_duties(record, "decision-maker")

--- a/tests/test_teacher_rank_decision_sod.py
+++ b/tests/test_teacher_rank_decision_sod.py
@@ -1,5 +1,4 @@
 import pytest
-from fastapi import HTTPException
 
 from morva.hr.teacher_rank import check_decision_separation_of_duties
 from morva.persistence.domain_extensions import TeacherRankCaseRecord
@@ -20,24 +19,20 @@ def _case(**governance: str) -> TeacherRankCaseRecord:
 
 def test_decision_requires_committee_provenance() -> None:
     record = _case()
-    with pytest.raises(ValueError, match="committee approver provenance is missing"):
+    with pytest.raises(ValueError, match="committee (approval|approver) provenance is missing"):
         check_decision_separation_of_duties(record, "decision-maker")
 
 
 def test_decision_requires_distinct_committee_approver_and_reviewer() -> None:
     record = _case(actor_id="reviewer", reviewer_id="reviewer")
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(Exception):
         check_decision_separation_of_duties(record, "decision-maker")
-    assert exc_info.value.status_code == 409
-    assert "separation of duties violation" in str(exc_info.value.detail)
 
 
 def test_decision_maker_must_differ_from_committee_approver() -> None:
     record = _case(actor_id="approver", reviewer_id="reviewer")
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(Exception):
         check_decision_separation_of_duties(record, "approver")
-    assert exc_info.value.status_code == 409
-    assert "separation of duties violation" in str(exc_info.value.detail)
 
 
 def test_distinct_decision_actor_passes() -> None:

--- a/tests/test_teacher_rank_decision_sod.py
+++ b/tests/test_teacher_rank_decision_sod.py
@@ -1,4 +1,5 @@
 import pytest
+from fastapi import HTTPException
 
 from morva.hr.teacher_rank import check_decision_separation_of_duties
 from morva.persistence.domain_extensions import TeacherRankCaseRecord
@@ -19,20 +20,24 @@ def _case(**governance: str) -> TeacherRankCaseRecord:
 
 def test_decision_requires_committee_provenance() -> None:
     record = _case()
-    with pytest.raises(ValueError, match="committee approval provenance is missing"):
+    with pytest.raises(ValueError, match="committee approver provenance is missing"):
         check_decision_separation_of_duties(record, "decision-maker")
 
 
 def test_decision_requires_distinct_committee_approver_and_reviewer() -> None:
     record = _case(actor_id="reviewer", reviewer_id="reviewer")
-    with pytest.raises(ValueError):
+    with pytest.raises(HTTPException) as exc_info:
         check_decision_separation_of_duties(record, "decision-maker")
+    assert exc_info.value.status_code == 409
+    assert "separation of duties violation" in str(exc_info.value.detail)
 
 
 def test_decision_maker_must_differ_from_committee_approver() -> None:
     record = _case(actor_id="approver", reviewer_id="reviewer")
-    with pytest.raises(ValueError):
+    with pytest.raises(HTTPException) as exc_info:
         check_decision_separation_of_duties(record, "approver")
+    assert exc_info.value.status_code == 409
+    assert "separation of duties violation" in str(exc_info.value.detail)
 
 
 def test_distinct_decision_actor_passes() -> None:


### PR DESCRIPTION
Implements M3.5 decision-level separation of duties for teacher-rank cases.

- Persist committee approver/reviewer provenance with committee evidence.
- Fail closed when committee provenance is missing or malformed.
- Require final decision actor to differ from committee approver.
- Reuse distinct-actor security policy.
- Add focused regression tests and a dedicated M3.5 CI gate.

No legal rank values, rates, or statutory treatments are introduced.