### PR TITLE
feat: M3.6 teacher rank decision provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,19 @@ jobs:
       - run: ruff check src/morva/hr/teacher_rank.py tests/test_teacher_rank_decision_sod.py
       - run: pytest -q tests/test_teacher_rank_decision_sod.py
 
+  m3-6-gate:
+    name: M3.6 teacher rank decision provenance gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff check src/morva/hr/teacher_rank.py src/morva/hr/teacher_rank_decision_provenance.py tests/test_teacher_rank_decision_provenance.py
+      - run: pytest -q tests/test_teacher_rank_decision_provenance.py
+
   web-build:
     runs-on: ubuntu-latest
     defaults:

--- a/src/morva/hr/teacher_rank.py
+++ b/src/morva/hr/teacher_rank.py
@@ -7,12 +7,23 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from morva.audit.persistence import append_audit_event
+from morva.hr.teacher_rank_decision_provenance import (
+    canonical_teacher_rank_decision_payload,
+    teacher_rank_decision_fingerprint,
+)
 from morva.hr.teacher_rank_evidence import check_teacher_rank_evidence
 from morva.persistence.domain_extensions import TeacherRankCaseRecord
 from morva.persistence.models import EmployeeRecord
 from morva.security.policy import require_distinct_actors
 
-_ALLOWED_TRANSITIONS = {"draft": {"assessed"}, "assessed": {"committee_approved"}, "committee_approved": {"decided"}, "decided": {"appeal_opened"}, "appeal_opened": {"appeal_resolved"}, "appeal_resolved": set()}
+_ALLOWED_TRANSITIONS = {
+    "draft": {"assessed"},
+    "assessed": {"committee_approved"},
+    "committee_approved": {"decided"},
+    "decided": {"appeal_opened"},
+    "appeal_opened": {"appeal_resolved"},
+    "appeal_resolved": set(),
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,29 +60,81 @@ def _employee(session: Session, employee_no: str) -> EmployeeRecord:
     return employee
 
 
-def _transition(session: Session, record: TeacherRankCaseRecord, *, target: str, actor_id: str, reason: str, reviewer_id: str | None = None) -> RankCaseResult:
+def _transition(
+    session: Session,
+    record: TeacherRankCaseRecord,
+    *,
+    target: str,
+    actor_id: str,
+    reason: str,
+    reviewer_id: str | None = None,
+) -> RankCaseResult:
     if target not in _ALLOWED_TRANSITIONS.get(record.status, set()):
         raise ValueError(f"invalid teacher rank transition: {record.status} -> {target}")
     if reviewer_id is not None:
         require_distinct_actors([actor_id, reviewer_id])
     record.status = target
-    append_audit_event(event_type=f"hr.teacher_rank.{target}", entity_type="teacher_rank_case", entity_id=str(record.id), actor_id=actor_id, payload={"employee_no": record.employee_no, "proposed_rank": record.proposed_rank}, reason=reason, session=session)
+    append_audit_event(
+        event_type=f"hr.teacher_rank.{target}",
+        entity_type="teacher_rank_case",
+        entity_id=str(record.id),
+        actor_id=actor_id,
+        payload={"employee_no": record.employee_no, "proposed_rank": record.proposed_rank},
+        reason=reason,
+        session=session,
+    )
     return RankCaseResult(case_id=record.id, status=record.status)
 
 
-def create_rank_case(session: Session, *, employee_no: str, proposed_rank: str, effect_period: str, actor_id: str, current_rank: str | None = None, assessment_payload: dict | None = None) -> RankCaseResult:
+def create_rank_case(
+    session: Session,
+    *,
+    employee_no: str,
+    proposed_rank: str,
+    effect_period: str,
+    actor_id: str,
+    current_rank: str | None = None,
+    assessment_payload: dict | None = None,
+) -> RankCaseResult:
     _employee(session, employee_no)
     if not proposed_rank.strip():
         raise ValueError("proposed_rank is required")
     if len(effect_period) != 7 or effect_period[4] != "-":
         raise ValueError("effect_period must use YYYY-MM")
-    duplicate = session.scalar(select(TeacherRankCaseRecord).where(TeacherRankCaseRecord.employee_no == employee_no, TeacherRankCaseRecord.effect_period == effect_period, TeacherRankCaseRecord.proposed_rank == proposed_rank))
+    duplicate = session.scalar(
+        select(TeacherRankCaseRecord).where(
+            TeacherRankCaseRecord.employee_no == employee_no,
+            TeacherRankCaseRecord.effect_period == effect_period,
+            TeacherRankCaseRecord.proposed_rank == proposed_rank,
+        )
+    )
     if duplicate is not None:
         return RankCaseResult(case_id=duplicate.id, status=duplicate.status)
-    record = TeacherRankCaseRecord(employee_no=employee_no, current_rank=current_rank, proposed_rank=proposed_rank, status="draft", effect_period=effect_period, assessment_payload=assessment_payload or {}, committee_payload={}, appeal_payload={})
+    record = TeacherRankCaseRecord(
+        employee_no=employee_no,
+        current_rank=current_rank,
+        proposed_rank=proposed_rank,
+        status="draft",
+        effect_period=effect_period,
+        assessment_payload=assessment_payload or {},
+        committee_payload={},
+        appeal_payload={},
+    )
     session.add(record)
     session.flush()
-    append_audit_event(event_type="hr.teacher_rank.created", entity_type="teacher_rank_case", entity_id=str(record.id), actor_id=actor_id, payload={"employee_no": employee_no, "effect_period": effect_period, "proposed_rank": proposed_rank}, reason="register teacher rank case", session=session)
+    append_audit_event(
+        event_type="hr.teacher_rank.created",
+        entity_type="teacher_rank_case",
+        entity_id=str(record.id),
+        actor_id=actor_id,
+        payload={
+            "employee_no": employee_no,
+            "effect_period": effect_period,
+            "proposed_rank": proposed_rank,
+        },
+        reason="register teacher rank case",
+        session=session,
+    )
     return RankCaseResult(case_id=record.id, status=record.status)
 
 
@@ -89,7 +152,14 @@ def approve_committee(session: Session, case_id: UUID, actor_id: str, committee:
     record = _case(session, case_id)
     require_distinct_actors([actor_id, reviewer_id])
     record.committee_payload = {**committee, "_governance": {"actor_id": actor_id, "reviewer_id": reviewer_id}}
-    return _transition(session, record, target="committee_approved", actor_id=actor_id, reviewer_id=reviewer_id, reason="approve rank committee evidence")
+    return _transition(
+        session,
+        record,
+        target="committee_approved",
+        actor_id=actor_id,
+        reviewer_id=reviewer_id,
+        reason="approve rank committee evidence",
+    )
 
 
 def decide_case(session: Session, case_id: UUID, actor_id: str, decision_reference: str) -> RankCaseResult:
@@ -100,8 +170,29 @@ def decide_case(session: Session, case_id: UUID, actor_id: str, decision_referen
     if not evidence_gate.ready:
         raise ValueError("teacher rank decision blocked by authoritative evidence gate: " + "; ".join(evidence_gate.blockers))
     check_decision_separation_of_duties(record, actor_id)
+    governance = record.committee_payload["_governance"]
+    provenance_payload = canonical_teacher_rank_decision_payload(
+        case_id=str(record.id),
+        employee_no=record.employee_no,
+        proposed_rank=record.proposed_rank,
+        effect_period=record.effect_period,
+        decision_reference=decision_reference,
+        committee_governance=governance,
+        evidence_fingerprint=getattr(evidence_gate, "fingerprint", ""),
+    )
+    fingerprint = teacher_rank_decision_fingerprint(provenance_payload)
+    record.committee_payload = {
+        **record.committee_payload,
+        "_decision_provenance": {"fingerprint": fingerprint, "payload": provenance_payload},
+    }
     record.decision_reference = decision_reference
-    return _transition(session, record, target="decided", actor_id=actor_id, reason="record authoritative rank decision")
+    return _transition(
+        session,
+        record,
+        target="decided",
+        actor_id=actor_id,
+        reason="record authoritative rank decision",
+    )
 
 
 def open_appeal(session: Session, case_id: UUID, actor_id: str, appeal: dict) -> RankCaseResult:
@@ -117,4 +208,11 @@ def resolve_appeal(session: Session, case_id: UUID, actor_id: str, resolution: d
         raise ValueError("appeal resolution is required")
     record = _case(session, case_id)
     record.appeal_payload = {**record.appeal_payload, "resolution": resolution}
-    return _transition(session, record, target="appeal_resolved", actor_id=actor_id, reviewer_id=reviewer_id, reason="resolve teacher rank appeal")
+    return _transition(
+        session,
+        record,
+        target="appeal_resolved",
+        actor_id=actor_id,
+        reviewer_id=reviewer_id,
+        reason="resolve teacher rank appeal",
+    )

--- a/src/morva/hr/teacher_rank.py
+++ b/src/morva/hr/teacher_rank.py
@@ -171,6 +171,7 @@ def decide_case(session: Session, case_id: UUID, actor_id: str, decision_referen
         raise ValueError("teacher rank decision blocked by authoritative evidence gate: " + "; ".join(evidence_gate.blockers))
     check_decision_separation_of_duties(record, actor_id)
     governance = record.committee_payload["_governance"]
+    evidence_fingerprint = f"{evidence_gate.evidence_id}:{evidence_gate.legal_source_id}"
     provenance_payload = canonical_teacher_rank_decision_payload(
         case_id=str(record.id),
         employee_no=record.employee_no,
@@ -178,7 +179,7 @@ def decide_case(session: Session, case_id: UUID, actor_id: str, decision_referen
         effect_period=record.effect_period,
         decision_reference=decision_reference,
         committee_governance=governance,
-        evidence_fingerprint=getattr(evidence_gate, "fingerprint", ""),
+        evidence_fingerprint=evidence_fingerprint,
     )
     fingerprint = teacher_rank_decision_fingerprint(provenance_payload)
     record.committee_payload = {

--- a/src/morva/hr/teacher_rank_decision_provenance.py
+++ b/src/morva/hr/teacher_rank_decision_provenance.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from hashlib import sha256
+from typing import Mapping
+
+
+def canonical_teacher_rank_decision_payload(
+    *,
+    case_id: str,
+    employee_no: str,
+    proposed_rank: str,
+    effect_period: str,
+    decision_reference: str,
+    committee_governance: Mapping[str, object],
+    evidence_fingerprint: str,
+) -> dict[str, object]:
+    return {
+        "case_id": case_id,
+        "employee_no": employee_no,
+        "proposed_rank": proposed_rank,
+        "effect_period": effect_period,
+        "decision_reference": decision_reference,
+        "committee_governance": dict(committee_governance),
+        "evidence_fingerprint": evidence_fingerprint,
+    }
+
+
+def teacher_rank_decision_fingerprint(payload: Mapping[str, object]) -> str:
+    canonical = json.dumps(
+        dict(payload),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return sha256(canonical.encode("utf-8")).hexdigest()

--- a/tests/test_teacher_rank_decision_provenance.py
+++ b/tests/test_teacher_rank_decision_provenance.py
@@ -1,0 +1,31 @@
+from morva.hr.teacher_rank_decision_provenance import (
+    canonical_teacher_rank_decision_payload,
+    teacher_rank_decision_fingerprint,
+)
+
+
+def test_teacher_rank_decision_fingerprint_is_deterministic() -> None:
+    payload = canonical_teacher_rank_decision_payload(
+        case_id="case-1",
+        employee_no="E-1",
+        proposed_rank="rank-A",
+        effect_period="1405-06",
+        decision_reference="DEC-1",
+        committee_governance={"actor_id": "approver", "reviewer_id": "reviewer"},
+        evidence_fingerprint="evidence-1:source-1",
+    )
+    assert teacher_rank_decision_fingerprint(payload) == teacher_rank_decision_fingerprint(payload)
+
+
+def test_teacher_rank_decision_fingerprint_changes_when_provenance_changes() -> None:
+    base = canonical_teacher_rank_decision_payload(
+        case_id="case-1",
+        employee_no="E-1",
+        proposed_rank="rank-A",
+        effect_period="1405-06",
+        decision_reference="DEC-1",
+        committee_governance={"actor_id": "approver", "reviewer_id": "reviewer"},
+        evidence_fingerprint="evidence-1:source-1",
+    )
+    changed = {**base, "decision_reference": "DEC-2"}
+    assert teacher_rank_decision_fingerprint(base) != teacher_rank_decision_fingerprint(changed)


### PR DESCRIPTION
Implements M3.6 cryptographic decision provenance for teacher-rank cases.

- Canonicalize decision inputs and committee governance metadata.
- Bind the decision fingerprint to the accepted authoritative evidence identifiers.
- Persist the fingerprint and canonical payload with the case record.
- Add deterministic tamper-detection regression tests.
- Add a dedicated M3.6 CI gate.

No legal rank values, rates, or statutory treatments are introduced.