### PR TITLE
feat: M3.7 teacher rank provenance verification (clean)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,19 @@ jobs:
       - run: ruff check src/morva/hr/teacher_rank.py src/morva/hr/teacher_rank_decision_provenance.py tests/test_teacher_rank_decision_provenance.py
       - run: pytest -q tests/test_teacher_rank_decision_provenance.py
 
+  m3-7-gate:
+    name: M3.7 teacher rank provenance verification gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff check src/morva/hr/teacher_rank_provenance_verifier.py tests/test_teacher_rank_provenance_verifier.py
+      - run: pytest -q tests/test_teacher_rank_provenance_verifier.py
+
   web-build:
     runs-on: ubuntu-latest
     defaults:

--- a/src/morva/hr/teacher_rank_provenance_verifier.py
+++ b/src/morva/hr/teacher_rank_provenance_verifier.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import hmac
+import re
+from typing import Mapping
+
+from morva.hr.teacher_rank_decision_provenance import teacher_rank_decision_fingerprint
+
+_HEX64 = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def verify_teacher_rank_decision_provenance(
+    *,
+    payload: Mapping[str, object],
+    fingerprint: str,
+) -> bool:
+    if not _HEX64.fullmatch(fingerprint):
+        return False
+    expected = teacher_rank_decision_fingerprint(payload)
+    return hmac.compare_digest(expected, fingerprint)

--- a/tests/test_teacher_rank_provenance_verifier.py
+++ b/tests/test_teacher_rank_provenance_verifier.py
@@ -1,0 +1,28 @@
+from morva.hr.teacher_rank_decision_provenance import teacher_rank_decision_fingerprint
+from morva.hr.teacher_rank_provenance_verifier import verify_teacher_rank_decision_provenance
+
+
+def test_verifier_accepts_unchanged_payload() -> None:
+    payload = {"case_id": "case-1", "decision_reference": "DEC-1"}
+    assert verify_teacher_rank_decision_provenance(
+        payload=payload,
+        fingerprint=teacher_rank_decision_fingerprint(payload),
+    )
+
+
+def test_verifier_rejects_modified_payload() -> None:
+    payload = {"case_id": "case-1", "decision_reference": "DEC-1"}
+    fingerprint = teacher_rank_decision_fingerprint(payload)
+    modified = {**payload, "decision_reference": "DEC-2"}
+    assert not verify_teacher_rank_decision_provenance(
+        payload=modified,
+        fingerprint=fingerprint,
+    )
+
+
+def test_verifier_rejects_malformed_fingerprint() -> None:
+    payload = {"case_id": "case-1", "decision_reference": "DEC-1"}
+    assert not verify_teacher_rank_decision_provenance(
+        payload=payload,
+        fingerprint="not-a-sha256",
+    )


### PR DESCRIPTION
Clean rebase of M3.7 teacher-rank provenance verification onto current main after resolving the merge-conflict state of PR #20.

- Recompute and verify persisted teacher-rank decision fingerprints.
- Detect tampering of canonical decision payloads.
- Preserve M3.6 provenance and M3.4/M3.5 gates.
- Add dedicated M3.7 CI coverage.

No legal values, rates, or statutory treatments are introduced.