### PR TITLE
feat: M3.8 persisted teacher rank provenance integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,19 @@ jobs:
       - run: ruff check src/morva/hr/teacher_rank_provenance_verifier.py tests/test_teacher_rank_provenance_verifier.py
       - run: pytest -q tests/test_teacher_rank_provenance_verifier.py
 
+  m3-8-gate:
+    name: M3.8 persisted teacher rank provenance integrity gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff check src/morva/hr/teacher_rank_decision_integrity.py tests/test_teacher_rank_decision_integrity.py
+      - run: pytest -q tests/test_teacher_rank_decision_integrity.py
+
   web-build:
     runs-on: ubuntu-latest
     defaults:

--- a/src/morva/api/v1/teacher_rank.py
+++ b/src/morva/api/v1/teacher_rank.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 
 from morva.hr.teacher_rank import approve_committee, create_rank_case, decide_case, open_appeal, resolve_appeal, submit_assessment
+from morva.hr.teacher_rank_decision_integrity import verify_persisted_teacher_rank_decision_provenance
 from morva.persistence.database import SessionLocal
 from morva.persistence.domain_extensions import TeacherRankCaseRecord
 from morva.persistence.models import EmployeeRecord
@@ -52,7 +53,22 @@ def _employee(session, employee_no: str) -> EmployeeRecord:
     return employee
 
 
+def _assert_decision_provenance(record: TeacherRankCaseRecord) -> None:
+    if record.status not in {"decided", "appeal_opened", "appeal_resolved"}:
+        return
+    if not record.decision_reference or not verify_persisted_teacher_rank_decision_provenance(
+        case_id=str(record.id),
+        employee_no=record.employee_no,
+        proposed_rank=record.proposed_rank,
+        effect_period=record.effect_period,
+        decision_reference=record.decision_reference,
+        committee_payload=record.committee_payload,
+    ):
+        raise HTTPException(status_code=409, detail="teacher rank decision provenance integrity check failed")
+
+
 def _case_payload(record: TeacherRankCaseRecord) -> dict[str, object]:
+    _assert_decision_provenance(record)
     return {
         "id": str(record.id),
         "employee_no": record.employee_no,

--- a/src/morva/hr/teacher_rank_decision_integrity.py
+++ b/src/morva/hr/teacher_rank_decision_integrity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hmac
 from collections.abc import Mapping
 
 from morva.hr.teacher_rank_decision_provenance import (
@@ -52,4 +53,5 @@ def verify_persisted_teacher_rank_decision_provenance(
     if dict(stored_payload) != expected_payload:
         return False
 
-    return teacher_rank_decision_fingerprint(expected_payload) == fingerprint
+    expected_fingerprint = teacher_rank_decision_fingerprint(expected_payload)
+    return hmac.compare_digest(expected_fingerprint, fingerprint)

--- a/src/morva/hr/teacher_rank_decision_integrity.py
+++ b/src/morva/hr/teacher_rank_decision_integrity.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from morva.hr.teacher_rank_decision_provenance import (
+    canonical_teacher_rank_decision_payload,
+    teacher_rank_decision_fingerprint,
+)
+
+
+def verify_persisted_teacher_rank_decision_provenance(
+    *,
+    case_id: str,
+    employee_no: str,
+    proposed_rank: str,
+    effect_period: str,
+    decision_reference: str,
+    committee_payload: Mapping[str, object],
+) -> bool:
+    """Verify that a persisted rank decision is still bound to its provenance.
+
+    The check is deliberately fail-closed. It validates the persisted provenance
+    envelope, reconstructs the canonical payload from the current decision record,
+    and then verifies both payload equality and its SHA-256 fingerprint.
+    """
+    provenance = committee_payload.get("_decision_provenance")
+    if not isinstance(provenance, Mapping):
+        return False
+
+    stored_payload = provenance.get("payload")
+    fingerprint = provenance.get("fingerprint")
+    if not isinstance(stored_payload, Mapping) or not isinstance(fingerprint, str):
+        return False
+
+    governance = committee_payload.get("_governance")
+    if not isinstance(governance, Mapping):
+        return False
+
+    evidence_fingerprint = stored_payload.get("evidence_fingerprint")
+    if not isinstance(evidence_fingerprint, str) or not evidence_fingerprint:
+        return False
+
+    expected_payload = canonical_teacher_rank_decision_payload(
+        case_id=case_id,
+        employee_no=employee_no,
+        proposed_rank=proposed_rank,
+        effect_period=effect_period,
+        decision_reference=decision_reference,
+        committee_governance=governance,
+        evidence_fingerprint=evidence_fingerprint,
+    )
+    if dict(stored_payload) != expected_payload:
+        return False
+
+    return teacher_rank_decision_fingerprint(expected_payload) == fingerprint

--- a/tests/test_teacher_rank_decision_integrity.py
+++ b/tests/test_teacher_rank_decision_integrity.py
@@ -1,0 +1,89 @@
+from morva.hr.teacher_rank_decision_integrity import verify_persisted_teacher_rank_decision_provenance
+from morva.hr.teacher_rank_decision_provenance import (
+    canonical_teacher_rank_decision_payload,
+    teacher_rank_decision_fingerprint,
+)
+
+
+def _payload() -> tuple[dict[str, object], dict[str, object]]:
+    governance = {"actor_id": "committee-1", "reviewer_id": "reviewer-1"}
+    payload = canonical_teacher_rank_decision_payload(
+        case_id="case-1",
+        employee_no="E-1",
+        proposed_rank="rank-X",
+        effect_period="1405-01",
+        decision_reference="DEC-1",
+        committee_governance=governance,
+        evidence_fingerprint="evidence-1:source-1",
+    )
+    return governance, payload
+
+
+def _committee_payload() -> dict[str, object]:
+    governance, payload = _payload()
+    return {
+        "_governance": governance,
+        "_decision_provenance": {
+            "payload": payload,
+            "fingerprint": teacher_rank_decision_fingerprint(payload),
+        },
+    }
+
+
+def test_integrity_accepts_unchanged_persisted_record() -> None:
+    assert verify_persisted_teacher_rank_decision_provenance(
+        case_id="case-1",
+        employee_no="E-1",
+        proposed_rank="rank-X",
+        effect_period="1405-01",
+        decision_reference="DEC-1",
+        committee_payload=_committee_payload(),
+    )
+
+
+def test_integrity_rejects_current_record_mutation() -> None:
+    assert not verify_persisted_teacher_rank_decision_provenance(
+        case_id="case-1",
+        employee_no="E-1",
+        proposed_rank="rank-Y",
+        effect_period="1405-01",
+        decision_reference="DEC-1",
+        committee_payload=_committee_payload(),
+    )
+
+
+def test_integrity_rejects_provenance_payload_mutation() -> None:
+    committee_payload = _committee_payload()
+    provenance = committee_payload["_decision_provenance"]
+    assert isinstance(provenance, dict)
+    stored_payload = provenance["payload"]
+    assert isinstance(stored_payload, dict)
+    stored_payload["decision_reference"] = "DEC-2"
+
+    assert not verify_persisted_teacher_rank_decision_provenance(
+        case_id="case-1",
+        employee_no="E-1",
+        proposed_rank="rank-X",
+        effect_period="1405-01",
+        decision_reference="DEC-1",
+        committee_payload=committee_payload,
+    )
+
+
+def test_integrity_rejects_missing_or_malformed_provenance() -> None:
+    assert not verify_persisted_teacher_rank_decision_provenance(
+        case_id="case-1",
+        employee_no="E-1",
+        proposed_rank="rank-X",
+        effect_period="1405-01",
+        decision_reference="DEC-1",
+        committee_payload={},
+    )
+    assert not verify_persisted_teacher_rank_decision_provenance(
+        case_id="case-1",
+        employee_no="E-1",
+        proposed_rank="rank-X",
+        effect_period="1405-01",
+        decision_reference="DEC-1",
+        committee_payload={"_decision_provenance": {"payload": {}, "fingerprint": "bad"}},
+    )


### PR DESCRIPTION
## M3.8

Adds a fail-closed integrity verifier for persisted teacher-rank decisions.

- Reconstructs canonical provenance from the current decision record.
- Requires the persisted provenance envelope and committee governance metadata.
- Rejects missing/malformed provenance, record mutations, payload mutations, and fingerprint mismatches.
- Adds dedicated tests and CI gate `M3.8 persisted teacher rank provenance integrity gate`.

This tranche introduces no legal rank values, statutory rates, or external authoritative data.