### PR TITLE
feat: M3.11 legal component matrix governance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,19 @@ jobs:
       - run: ruff check src/morva/personnel/order_approval.py src/morva/personnel/order_registry.py tests/test_personnel_order_lifecycle_m3_10.py
       - run: pytest -q tests/test_personnel_order_lifecycle_m3_10.py
 
+  m3-11-gate:
+    name: M3.11 legal component matrix gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff check src/morva/rules/rule_pack_1405.py tests/test_legal_component_matrix_1405.py
+      - run: pytest -q tests/test_legal_component_matrix_1405.py
+
   web-build:
     runs-on: ubuntu-latest
     defaults:

--- a/docs/M3_11_LEGAL_COMPONENT_MATRIX.md
+++ b/docs/M3_11_LEGAL_COMPONENT_MATRIX.md
@@ -1,0 +1,31 @@
+# M3.11 — Legal Component Matrix and 1405 Rule Pack Governance
+
+## هدف
+
+این tranche ماتریس کامل اجزای محاسبه حقوق سال ۱۴۰۵ را به یک manifest ماشین‌خوان تبدیل می‌کند و آن را به Rule Pack سالانه متصل می‌کند.
+
+## اصل ایمنی
+
+این manifest به‌تنهایی هیچ قاعده‌ای را برای پرداخت واقعی فعال نمی‌کند. همه اجزا عمداً `review_required` هستند تا منبع اولیه، تاریخ اثر، دامنه مشمولان، نحوه برخورد مالیات/بیمه/بازنشستگی، شواهد regression و تأیید مستقل حقوقی/مالی ثبت شود.
+
+## پوشش
+
+ماتریس `docs/legal/rule-packs/1405/component-matrix-1405.yml` تمام اجزای الزامی تعریف‌شده در `REQUIRED_1405_COMPONENTS` را پوشش می‌دهد:
+
+`JOB_RIGHT`, `INCUMBENT_RIGHT`, `JOB_ALLOWANCE`, `RANK_ALLOWANCE`, `FAMILY_ALLOWANCE`, `CHILD_ALLOWANCE`, `OVERTIME`, `TEACHING_FEE`, `REGION_WEATHER`, `TAX`, `PENSION`, `INSURANCE`, `LOAN`, `COURT_ORDER`.
+
+## قواعد انتشار
+
+- تفاوت سال‌های ۱۴۰۴ و ۱۴۰۵ باید با نسخه مستقل Rule Pack حفظ شود.
+- منبع اولیه و وضعیت تأیید آن باید پیش از activation ثبت شود.
+- treatment و سه پرچم `taxable/pensionable/insurable` نباید از fixture یا مشاهده منبع به‌صورت ضمنی استنتاج شوند.
+- reviewer و approver باید مستقل باشند.
+- هر تغییر حقوقی باید با Rule Pack جدید و regression evidence منتشر شود؛ نسخه قبلی برای historical replay حفظ می‌شود.
+
+## شواهد CI
+
+`tests/test_legal_component_matrix_1405.py` پوشش اجزا، fail-closed بودن و وجود فیلدهای حقوقی/درمانی هر جزء را کنترل می‌کند. گیت مستقل `M3.11 legal component matrix gate` همین کنترل‌ها را در CI اجرا می‌کند.
+
+## دامنه این tranche
+
+این تغییر، زیرساخت و پوشش ساختاری ماتریس را کامل می‌کند؛ «تأیید قانونی نهایی» همچنان وابسته به بارگذاری متن منابع اولیه و تأیید رسمی کارشناسان حقوقی و مالی است و تا آن زمان هیچ Rule تولیدی فعال محسوب نمی‌شود.

--- a/docs/legal/rule-packs/1405/component-matrix-1405.yml
+++ b/docs/legal/rule-packs/1405/component-matrix-1405.yml
@@ -1,0 +1,110 @@
+version: "1405-component-matrix-1.0"
+status: review_required
+effective_year: 1405
+currency: IRR
+activation_policy: "fail_closed_until_primary_source_and_formal_approval"
+required_components:
+  - code: JOB_RIGHT
+    title: "حق شغل"
+    treatment: earning
+    source_id: LMS-CSC-64-68
+    legal_article: "64"
+    legal_source_status: review_required
+  - code: INCUMBENT_RIGHT
+    title: "حق شاغل"
+    treatment: earning
+    source_id: LMS-CSC-64-68
+    legal_article: "65"
+    legal_source_status: review_required
+  - code: JOB_ALLOWANCE
+    title: "فوق‌العاده شغل / مزایای شغلی"
+    treatment: earning
+    source_id: LMS-CSC-64-68
+    legal_article: "68"
+    legal_source_status: review_required
+  - code: RANK_ALLOWANCE
+    title: "فوق‌العاده رتبه‌بندی"
+    treatment: earning
+    source_id: TEACHER-RANK-REG-1404
+    legal_article: "2, 3, 5, 6, 7, 10, 13, 17, 18, 23"
+    legal_source_status: review_required
+  - code: FAMILY_ALLOWANCE
+    title: "عائله‌مندی"
+    treatment: earning
+    source_id: LMS-CSC-64-68
+    legal_article: "68"
+    legal_source_status: review_required
+  - code: CHILD_ALLOWANCE
+    title: "اولاد"
+    treatment: earning
+    source_id: LMS-CSC-64-68
+    legal_article: "68"
+    legal_source_status: review_required
+  - code: OVERTIME
+    title: "اضافه‌کار"
+    treatment: earning
+    source_id: PAY-1405
+    legal_article: "executive-instruction-required"
+    legal_source_status: review_required
+  - code: TEACHING_FEE
+    title: "حق‌التدریس"
+    treatment: earning
+    source_id: PAY-1405
+    legal_article: "executive-instruction-required"
+    legal_source_status: review_required
+  - code: REGION_WEATHER
+    title: "محرومیت / مناطق کمتر توسعه‌یافته و شرایط اقلیمی"
+    treatment: earning
+    source_id: PAY-1405
+    legal_article: "executive-instruction-required"
+    legal_source_status: review_required
+  - code: TAX
+    title: "مالیات بر درآمد حقوق"
+    treatment: deduction
+    source_id: TAX-1405
+    legal_article: "budget-and-tax-provisions"
+    legal_source_status: review_required
+  - code: PENSION
+    title: "کسور بازنشستگی"
+    treatment: deduction
+    source_id: PAY-1405
+    legal_article: "fund-specific-instruction-required"
+    legal_source_status: review_required
+  - code: INSURANCE
+    title: "بیمه"
+    treatment: deduction
+    source_id: PAY-1405
+    legal_article: "insurance-specific-instruction-required"
+    legal_source_status: review_required
+  - code: LOAN
+    title: "اقساط وام"
+    treatment: deduction
+    source_id: PAY-1405
+    legal_article: "contract-and-payroll-source-required"
+    legal_source_status: review_required
+  - code: COURT_ORDER
+    title: "کسورات قضایی"
+    treatment: deduction
+    source_id: PAY-1405
+    legal_article: "judicial-order-required"
+    legal_source_status: review_required
+
+rules:
+  - code: LEGAL_ACTIVATION
+    requirement: "every component requires an approved primary legal source, effective dates, reviewed evidence, distinct approval, and regression evidence"
+  - code: YEAR_BOUNDARY
+    requirement: "1404 and 1405 rules must be versioned separately and never inferred from each other"
+  - code: NO_IMPLICIT_TREATMENT
+    requirement: "taxable, pensionable, and insurable flags remain explicit until the source treatment is approved"
+  - code: NO_ACTIVE_RESEARCH_FIXTURE
+    requirement: "review_required and researched_not_activated entries cannot drive production payroll"
+
+source_dependencies:
+  LMS-CSC-64-68: "Civil Service Management Law, Chapter Ten"
+  TEACHER-RANK-REG-1404: "Executive Regulation of Teacher Ranking Law and amendments"
+  TAX-1405: "Budget 1405 and related tax rules"
+  PAY-1405: "Executive 1405 payroll/payment instructions"
+
+notes:
+  - "This manifest completes structural component coverage; it does not legally approve any component."
+  - "Primary-source documents and expert approvals must be attached to the governed evidence records before activation."

--- a/tests/test_legal_component_matrix_1405.py
+++ b/tests/test_legal_component_matrix_1405.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import re
+
+from morva.rules.rule_pack_1405 import REQUIRED_1405_COMPONENTS
+
+
+MATRIX_PATH = Path("docs/legal/rule-packs/1405/component-matrix-1405.yml")
+
+
+def _matrix_text() -> str:
+    return MATRIX_PATH.read_text(encoding="utf-8")
+
+
+def test_1405_matrix_covers_every_required_component_once():
+    text = _matrix_text()
+    codes = re.findall(r"^  - code: ([A-Z0-9_]+)$", text, flags=re.MULTILINE)
+    assert codes == list(REQUIRED_1405_COMPONENTS)
+    assert len(codes) == len(set(codes))
+
+
+def test_1405_matrix_is_fail_closed_and_review_required():
+    text = _matrix_text()
+    assert 'status: review_required' in text
+    assert 'activation_policy: "fail_closed_until_primary_source_and_formal_approval"' in text
+    assert "review_required and researched_not_activated entries cannot drive production payroll" in text
+
+
+def test_1405_matrix_has_explicit_legal_and_treatment_fields_for_each_component():
+    text = _matrix_text()
+    blocks = re.split(r"(?=^  - code: )", text, flags=re.MULTILINE)
+    component_blocks = [block for block in blocks if block.startswith("  - code: ")]
+    assert len(component_blocks) == len(REQUIRED_1405_COMPONENTS)
+    for block in component_blocks:
+        assert re.search(r"^    title: .+$", block, flags=re.MULTILINE)
+        assert re.search(r"^    treatment: (earning|deduction|informational)$", block, flags=re.MULTILINE)
+        assert re.search(r"^    source_id: [A-Z0-9-]+$", block, flags=re.MULTILINE)
+        assert re.search(r"^    legal_article: .+$", block, flags=re.MULTILINE)
+        assert re.search(r"^    legal_source_status: review_required$", block, flags=re.MULTILINE)


### PR DESCRIPTION
## M3.11 — Legal Component Matrix

This tranche adds the complete 1405 calculation-component coverage manifest and an independent CI gate.

### Included
- machine-readable `docs/legal/rule-packs/1405/component-matrix-1405.yml`
- explicit legal source/treatment metadata for every required 1405 component
- fail-closed activation policy; all entries remain `review_required`
- regression/coverage tests in `tests/test_legal_component_matrix_1405.py`
- dedicated `M3.11 legal component matrix gate`
- governance documentation in `docs/M3_11_LEGAL_COMPONENT_MATRIX.md`

### Safety
No legal rule is promoted to production. Final activation remains blocked until primary-source documents, effective dates, approved evidence, distinct review/approval and regression evidence are formally recorded.