### PR TITLE
fix: align 1405 component contract and explicit treatments

### DIFF
--- a/docs/legal/rule-packs/1405/component-matrix-1405.yml
+++ b/docs/legal/rule-packs/1405/component-matrix-1405.yml
@@ -1,4 +1,4 @@
-version: "1405-component-matrix-1.0"
+version: "1405-component-matrix-1.1"
 status: review_required
 effective_year: 1405
 currency: IRR
@@ -10,84 +10,126 @@ required_components:
     source_id: LMS-CSC-64-68
     legal_article: "64"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: INCUMBENT_RIGHT
     title: "حق شاغل"
     treatment: earning
     source_id: LMS-CSC-64-68
     legal_article: "65"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: JOB_ALLOWANCE
     title: "فوق‌العاده شغل / مزایای شغلی"
     treatment: earning
     source_id: LMS-CSC-64-68
     legal_article: "68"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: RANK_ALLOWANCE
     title: "فوق‌العاده رتبه‌بندی"
     treatment: earning
     source_id: TEACHER-RANK-REG-1404
     legal_article: "2, 3, 5, 6, 7, 10, 13, 17, 18, 23"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: FAMILY_ALLOWANCE
     title: "عائله‌مندی"
     treatment: earning
     source_id: LMS-CSC-64-68
     legal_article: "68"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: CHILD_ALLOWANCE
     title: "اولاد"
     treatment: earning
     source_id: LMS-CSC-64-68
     legal_article: "68"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: OVERTIME
     title: "اضافه‌کار"
     treatment: earning
     source_id: PAY-1405
     legal_article: "executive-instruction-required"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: TEACHING_FEE
     title: "حق‌التدریس"
     treatment: earning
     source_id: PAY-1405
     legal_article: "executive-instruction-required"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: REGION_WEATHER
     title: "محرومیت / مناطق کمتر توسعه‌یافته و شرایط اقلیمی"
     treatment: earning
     source_id: PAY-1405
     legal_article: "executive-instruction-required"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: TAX
     title: "مالیات بر درآمد حقوق"
     treatment: deduction
     source_id: TAX-1405
     legal_article: "budget-and-tax-provisions"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: PENSION
     title: "کسور بازنشستگی"
     treatment: deduction
     source_id: PAY-1405
     legal_article: "fund-specific-instruction-required"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: INSURANCE
     title: "بیمه"
     treatment: deduction
     source_id: PAY-1405
     legal_article: "insurance-specific-instruction-required"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: LOAN
     title: "اقساط وام"
     treatment: deduction
     source_id: PAY-1405
     legal_article: "contract-and-payroll-source-required"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
   - code: COURT_ORDER
     title: "کسورات قضایی"
     treatment: deduction
     source_id: PAY-1405
     legal_article: "judicial-order-required"
     legal_source_status: review_required
+    taxable: review_required
+    pensionable: review_required
+    insurable: review_required
 
 rules:
   - code: LEGAL_ACTIVATION
@@ -95,7 +137,7 @@ rules:
   - code: YEAR_BOUNDARY
     requirement: "1404 and 1405 rules must be versioned separately and never inferred from each other"
   - code: NO_IMPLICIT_TREATMENT
-    requirement: "taxable, pensionable, and insurable flags remain explicit until the source treatment is approved"
+    requirement: "taxable, pensionable, and insurable flags must be explicit; review_required means unresolved and non-activatable"
   - code: NO_ACTIVE_RESEARCH_FIXTURE
     requirement: "review_required and researched_not_activated entries cannot drive production payroll"
 
@@ -108,3 +150,4 @@ source_dependencies:
 notes:
   - "This manifest completes structural component coverage; it does not legally approve any component."
   - "Primary-source documents and expert approvals must be attached to the governed evidence records before activation."
+  - "Treatment flags are deliberately unresolved until authoritative source evidence is approved; no default false value is implied by this manifest."

--- a/src/morva/rules/rule_pack_1405.py
+++ b/src/morva/rules/rule_pack_1405.py
@@ -11,6 +11,7 @@ REQUIRED_1405_COMPONENTS: tuple[str, ...] = (
     "CHILD_ALLOWANCE",
     "OVERTIME",
     "TEACHING_FEE",
+    "REGION_WEATHER",
     "TAX",
     "PENSION",
     "INSURANCE",

--- a/tests/test_legal_component_matrix_1405.py
+++ b/tests/test_legal_component_matrix_1405.py
@@ -11,6 +11,11 @@ def _matrix_text() -> str:
     return MATRIX_PATH.read_text(encoding="utf-8")
 
 
+def _component_blocks(text: str) -> list[str]:
+    blocks = re.split(r"(?=^  - code: )", text, flags=re.MULTILINE)
+    return [block for block in blocks if block.startswith("  - code: ")]
+
+
 def test_1405_matrix_covers_every_required_component_once():
     text = _matrix_text()
     codes = re.findall(r"^  - code: ([A-Z0-9_]+)$", text, flags=re.MULTILINE)
@@ -27,8 +32,7 @@ def test_1405_matrix_is_fail_closed_and_review_required():
 
 def test_1405_matrix_has_explicit_legal_and_treatment_fields_for_each_component():
     text = _matrix_text()
-    blocks = re.split(r"(?=^  - code: )", text, flags=re.MULTILINE)
-    component_blocks = [block for block in blocks if block.startswith("  - code: ")]
+    component_blocks = _component_blocks(text)
     assert len(component_blocks) == len(REQUIRED_1405_COMPONENTS)
     for block in component_blocks:
         assert re.search(r"^    title: .+$", block, flags=re.MULTILINE)
@@ -36,3 +40,15 @@ def test_1405_matrix_has_explicit_legal_and_treatment_fields_for_each_component(
         assert re.search(r"^    source_id: [A-Z0-9-]+$", block, flags=re.MULTILINE)
         assert re.search(r"^    legal_article: .+$", block, flags=re.MULTILINE)
         assert re.search(r"^    legal_source_status: review_required$", block, flags=re.MULTILINE)
+        for field in ("taxable", "pensionable", "insurable"):
+            assert re.search(rf"^    {field}: (true|false|review_required)$", block, flags=re.MULTILINE)
+
+
+def test_1405_deduction_components_are_explicitly_classified():
+    text = _matrix_text()
+    component_blocks = _component_blocks(text)
+    expected_deductions = {"TAX", "PENSION", "INSURANCE", "LOAN", "COURT_ORDER"}
+    for block in component_blocks:
+        code = re.search(r"^  - code: ([A-Z0-9_]+)$", block, flags=re.MULTILINE).group(1)
+        treatment = re.search(r"^    treatment: (earning|deduction|informational)$", block, flags=re.MULTILINE).group(1)
+        assert (treatment == "deduction") == (code in expected_deductions)

--- a/tests/test_rule_pack_1405.py
+++ b/tests/test_rule_pack_1405.py
@@ -6,6 +6,13 @@ def test_1405_rule_pack_detection_and_required_coverage_manifest():
     assert is_1405_rule_pack("1405.1")
     assert not is_1405_rule_pack("1404.9")
     assert len(REQUIRED_1405_COMPONENTS) == len(set(REQUIRED_1405_COMPONENTS))
-    assert {"JOB_RIGHT", "TAX", "PENSION", "INSURANCE", "COURT_ORDER"}.issubset(
-        REQUIRED_1405_COMPONENTS
-    )
+    assert {
+        "JOB_RIGHT",
+        "TAX",
+        "PENSION",
+        "INSURANCE",
+        "LOAN",
+        "COURT_ORDER",
+        "REGION_WEATHER",
+    }.issubset(REQUIRED_1405_COMPONENTS)
+    assert len(REQUIRED_1405_COMPONENTS) == 14


### PR DESCRIPTION
## M3.11 follow-up — contract and treatment governance fix

This PR fixes two governance inconsistencies found immediately after M3.11 landed on `main`:

- aligns `REQUIRED_1405_COMPONENTS` with the 14-component machine-readable matrix, including `REGION_WEATHER`;
- locks the required component count at 14 in regression coverage;
- makes `taxable`, `pensionable`, and `insurable` explicit for every 1405 component;
- keeps all three treatment flags `review_required` until authoritative legal/financial evidence is approved;
- versions the component matrix manifest to `1405-component-matrix-1.1`.

No statutory rate, threshold, or production legal treatment is introduced by this change. Production activation remains fail-closed.
