### PR TITLE
fix: enforce rule activation provenance integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,19 @@ jobs:
       - run: ruff check src/morva/ledger/deductions.py tests/test_deduction_ledger_safety.py
       - run: pytest -q tests/test_deduction_ledger_safety.py
 
+  rule-activation-integrity-gate:
+    name: Rule activation provenance integrity gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff check src/morva/rules/activation.py tests/test_rule_activation_integrity.py
+      - run: pytest -q tests/test_rule_activation_integrity.py
+
   web-build:
     runs-on: ubuntu-latest
     defaults:

--- a/docs/legal/ACTIVATION_INTEGRITY.md
+++ b/docs/legal/ACTIVATION_INTEGRITY.md
@@ -1,0 +1,15 @@
+# Rule Activation Provenance Contract
+
+A rule pack may be activated only when the selected components have complete, immutable provenance.
+
+For every selected component, activation requires:
+
+1. The Rule Pack is `approved` or `published` and carries immutable rules/source hashes.
+2. Matching rule evidence exists for the component and is `approved` or `published`.
+3. The evidence contains legal issuer, article, population scope, source hash, and regression-suite hash.
+4. The evidence has a reviewer and approver, and they are distinct actors.
+5. The evidence has an approval timestamp.
+6. The referenced legal source exists and is `approved` or `published`.
+7. The legal source document hash exactly matches the evidence source hash.
+
+These checks are deliberately structural. They do not invent statutory rates, exemptions, or population-specific treatments. A missing or inconsistent legal record blocks activation rather than silently choosing a default.

--- a/src/morva/rules/activation.py
+++ b/src/morva/rules/activation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from morva.persistence.enterprise_models import RuleEvidenceRecord
+from morva.persistence.enterprise_models import LegalSourceRecord, RuleEvidenceRecord
 from morva.persistence.models import RulePackRecord
 
 
@@ -27,12 +27,31 @@ def require_authoritative_pack(
             RuleEvidenceRecord.component_code.in_(component_codes),
         )
     ).all()
-    by_component = {item.component_code: item for item in evidences if item.status in {"approved", "published"}}
+    by_component = {
+        item.component_code: item
+        for item in evidences
+        if item.status in {"approved", "published"}
+    }
     missing = sorted(component_codes - set(by_component))
     if missing:
         raise RuleActivationBlocked(f"Rule Pack evidence is incomplete for components: {missing}")
+
     for evidence in by_component.values():
         if not evidence.source_hash or not evidence.article or not evidence.issuer or not evidence.population_scope:
             raise RuleActivationBlocked(f"incomplete legal evidence for component {evidence.component_code}")
         if not evidence.regression_suite_hash:
             raise RuleActivationBlocked(f"regression evidence is missing for component {evidence.component_code}")
+        if not evidence.reviewed_by or not evidence.approved_by or evidence.reviewed_by == evidence.approved_by:
+            raise RuleActivationBlocked(
+                f"reviewer and approver must be distinct for component {evidence.component_code}"
+            )
+        if evidence.approved_at is None:
+            raise RuleActivationBlocked(f"approval timestamp is missing for component {evidence.component_code}")
+
+        source = session.get(LegalSourceRecord, evidence.legal_source_id)
+        if source is None:
+            raise RuleActivationBlocked(f"legal source is missing for component {evidence.component_code}")
+        if source.status not in {"approved", "published"}:
+            raise RuleActivationBlocked(f"legal source is not approved for component {evidence.component_code}")
+        if source.document_hash != evidence.source_hash:
+            raise RuleActivationBlocked(f"source hash mismatch for component {evidence.component_code}")

--- a/tests/test_rule_activation_integrity.py
+++ b/tests/test_rule_activation_integrity.py
@@ -1,0 +1,126 @@
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+
+from morva.persistence.enterprise_models import LegalSourceRecord, RuleEvidenceRecord
+from morva.persistence.models import RulePackRecord
+from morva.rules.activation import RuleActivationBlocked, require_authoritative_pack
+
+
+class _ScalarResult:
+    def __init__(self, values: list[RuleEvidenceRecord]) -> None:
+        self._values = values
+
+    def all(self) -> list[RuleEvidenceRecord]:
+        return self._values
+
+
+class _SessionStub:
+    def __init__(self, evidence: list[RuleEvidenceRecord], source: LegalSourceRecord | None) -> None:
+        self._evidence = evidence
+        self._source = source
+
+    def scalars(self, _query: object) -> _ScalarResult:
+        return _ScalarResult(self._evidence)
+
+    def get(self, _model: type[LegalSourceRecord], _source_id: object) -> LegalSourceRecord | None:
+        return self._source
+
+
+def _fixture(
+    *,
+    source_status: str = "approved",
+    evidence_source_hash: str = "a" * 64,
+    source_hash: str = "a" * 64,
+    reviewed_by: str | None = "legal-reviewer",
+    approved_by: str | None = "finance-approver",
+    approved_at: datetime | None = datetime(2026, 9, 9, 10, 0),
+) -> tuple[RulePackRecord, RuleEvidenceRecord, LegalSourceRecord]:
+    source_id = uuid4()
+    source = LegalSourceRecord(
+        id=source_id,
+        citation="test source",
+        issuer="test issuer",
+        adoption_date="2026-01-01",
+        effective_from="2026-01-01",
+        document_hash=source_hash,
+        status=source_status,
+    )
+    evidence = RuleEvidenceRecord(
+        id=uuid4(),
+        rule_pack_version="1405-test-1.0",
+        component_code="TAX",
+        legal_source_id=source_id,
+        issuer="test issuer",
+        article="1",
+        population_scope="test population",
+        source_hash=evidence_source_hash,
+        regression_suite_hash="b" * 64,
+        status="approved",
+        reviewed_by=reviewed_by,
+        approved_by=approved_by,
+        approved_at=approved_at,
+    )
+    pack = RulePackRecord(
+        id=uuid4(),
+        version="1405-test-1.0",
+        status="approved",
+        legal_source_hash="c" * 64,
+        rules_hash="d" * 64,
+    )
+    return pack, evidence, source
+
+
+def test_activation_accepts_complete_provenance() -> None:
+    pack, evidence, source = _fixture()
+
+    require_authoritative_pack(
+        _SessionStub([evidence], source),
+        pack=pack,
+        component_codes={"TAX"},
+    )
+
+
+def test_activation_blocks_source_hash_mismatch() -> None:
+    pack, evidence, source = _fixture(evidence_source_hash="e" * 64)
+
+    with pytest.raises(RuleActivationBlocked, match="source hash mismatch"):
+        require_authoritative_pack(
+            _SessionStub([evidence], source),
+            pack=pack,
+            component_codes={"TAX"},
+        )
+
+
+def test_activation_blocks_unapproved_source() -> None:
+    pack, evidence, source = _fixture(source_status="reviewed")
+
+    with pytest.raises(RuleActivationBlocked, match="legal source is not approved"):
+        require_authoritative_pack(
+            _SessionStub([evidence], source),
+            pack=pack,
+            component_codes={"TAX"},
+        )
+
+
+def test_activation_requires_distinct_review_and_approval_actors() -> None:
+    pack, evidence, source = _fixture(reviewed_by="same-user", approved_by="same-user")
+
+    with pytest.raises(RuleActivationBlocked, match="must be distinct"):
+        require_authoritative_pack(
+            _SessionStub([evidence], source),
+            pack=pack,
+            component_codes={"TAX"},
+        )
+
+
+def test_activation_requires_approval_timestamp() -> None:
+    pack, evidence, source = _fixture(approved_at=None)
+
+    with pytest.raises(RuleActivationBlocked, match="approval timestamp"):
+        require_authoritative_pack(
+            _SessionStub([evidence], source),
+            pack=pack,
+            component_codes={"TAX"},
+        )


### PR DESCRIPTION
## Summary
- require approved/published evidence to retain distinct review and approval actors
- require an approval timestamp before activation
- resolve the referenced legal source and verify its approval state
- verify the legal source document hash matches the evidence hash
- add focused regression coverage and a CI gate
- document the activation provenance contract without inventing statutory treatments

## Validation
Local execution was attempted but the environment could not resolve github.com, so tests were not claimed as executed here.