### PR TITLE
feat: add deterministic golden output fingerprints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,19 @@ jobs:
       - run: ruff check src/morva/rules/calculation_matrix.py tests/test_calculation_matrix.py
       - run: pytest -q tests/test_calculation_matrix.py
 
+  golden-output-fingerprint-gate:
+    name: Golden output fingerprint gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff check src/morva/rules/engine.py src/morva/rules/regression.py tests/test_rule_result_fingerprint.py
+      - run: pytest -q tests/test_rule_result_fingerprint.py
+
   web-build:
     runs-on: ubuntu-latest
     defaults:

--- a/src/morva/rules/engine.py
+++ b/src/morva/rules/engine.py
@@ -38,6 +38,9 @@ class RuleResult:
     amount: Decimal
     explanation: str
     legal_reference: str | None = None
+    taxable: bool = False
+    pensionable: bool = False
+    insurable: bool = False
 
 
 class RuleNotFoundError(LookupError):
@@ -93,4 +96,12 @@ class RuleEngine:
         if amount < 0:
             raise ValueError(f"Rule {code} produced a negative amount")
         explanation = f"{definition.title} [{definition.code}] applied for {context.effective_date.isoformat()}"
-        return RuleResult(code, amount, explanation, definition.legal_reference)
+        return RuleResult(
+            code,
+            amount,
+            explanation,
+            definition.legal_reference,
+            definition.taxable,
+            definition.pensionable,
+            definition.insurable,
+        )

--- a/src/morva/rules/regression.py
+++ b/src/morva/rules/regression.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from decimal import Decimal
+from typing import Mapping
+
+from .engine import RuleResult
+
+
+def canonical_result_payload(result: RuleResult) -> dict[str, object]:
+    return {
+        "code": result.code,
+        "amount": format(Decimal(result.amount), "f"),
+        "legal_reference": result.legal_reference,
+        "taxable": result.taxable,
+        "pensionable": result.pensionable,
+        "insurable": result.insurable,
+    }
+
+
+def fingerprint_rule_result(result: RuleResult) -> str:
+    payload = json.dumps(
+        canonical_result_payload(result),
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def fingerprint_values(values: Mapping[str, Decimal]) -> str:
+    canonical = {key: format(Decimal(value), "f") for key, value in sorted(values.items())}
+    payload = json.dumps(canonical, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/tests/test_rule_result_fingerprint.py
+++ b/tests/test_rule_result_fingerprint.py
@@ -24,7 +24,9 @@ def test_rule_result_fingerprint_is_stable() -> None:
     assert fingerprint_values({"amount": Decimal("123.4500")}) == fingerprint_values(
         {"amount": Decimal("123.45")}
     )
-    assert fingerprint_rule_result(result) == "039154840b2c09f6363ac29ea847f19e395269a4f8b12ae17ed86487eb5d0a18"
+    assert fingerprint_rule_result(result) == (
+        "039154840b2c09f6363ac29ea847f19e395269a4f8b12ae17ed86487eb5d0a18"
+    )
 
 
 def test_classification_changes_fingerprint() -> None:

--- a/tests/test_rule_result_fingerprint.py
+++ b/tests/test_rule_result_fingerprint.py
@@ -1,0 +1,52 @@
+from datetime import date
+from decimal import Decimal
+
+from morva.rules.engine import RuleContext, RuleDefinition, RuleEngine
+from morva.rules.regression import fingerprint_rule_result, fingerprint_values
+
+
+def test_rule_result_fingerprint_is_stable() -> None:
+    definition = RuleDefinition(
+        code="TAX",
+        title="Synthetic tax regression",
+        effective_from=date(2026, 1, 1),
+        expression={"op": "value", "name": "amount"},
+        legal_reference="synthetic:TAX",
+        taxable=True,
+        pensionable=False,
+        insurable=False,
+    )
+    result = RuleEngine([definition]).calculate(
+        "TAX",
+        RuleContext(date(2026, 1, 1), {"amount": Decimal("123.4500")}),
+    )
+
+    assert fingerprint_values({"amount": Decimal("123.4500")}) == fingerprint_values(
+        {"amount": Decimal("123.45")}
+    )
+    assert fingerprint_rule_result(result) == "a1f2e62b6a6f0ac8bb5c6c37815cb4ce2a9ea5fc8fca4c7f365e1112b3a2a5ef"
+
+
+def test_classification_changes_fingerprint() -> None:
+    base = RuleResultProxy = None
+    definition = RuleDefinition(
+        code="INSURANCE",
+        title="Synthetic insurance regression",
+        effective_from=date(2026, 1, 1),
+        expression={"op": "value", "name": "amount"},
+        legal_reference="synthetic:INSURANCE",
+    )
+    result = RuleEngine([definition]).calculate(
+        "INSURANCE",
+        RuleContext(date(2026, 1, 1), {"amount": Decimal("10")}),
+    )
+    classified = result.__class__(
+        result.code,
+        result.amount,
+        result.explanation,
+        result.legal_reference,
+        True,
+        False,
+        False,
+    )
+    assert fingerprint_rule_result(result) != fingerprint_rule_result(classified)

--- a/tests/test_rule_result_fingerprint.py
+++ b/tests/test_rule_result_fingerprint.py
@@ -24,11 +24,10 @@ def test_rule_result_fingerprint_is_stable() -> None:
     assert fingerprint_values({"amount": Decimal("123.4500")}) == fingerprint_values(
         {"amount": Decimal("123.45")}
     )
-    assert fingerprint_rule_result(result) == "a1f2e62b6a6f0ac8bb5c6c37815cb4ce2a9ea5fc8fca4c7f365e1112b3a2a5ef"
+    assert fingerprint_rule_result(result) == "039154840b2c09f6363ac29ea847f19e395269a4f8b12ae17ed86487eb5d0a18"
 
 
 def test_classification_changes_fingerprint() -> None:
-    base = RuleResultProxy = None
     definition = RuleDefinition(
         code="INSURANCE",
         title="Synthetic insurance regression",


### PR DESCRIPTION
## Summary
- carry taxable/pensionable/insurable classification into RuleResult
- add canonical SHA-256 fingerprints for rule results and input values
- lock a synthetic golden output fingerprint for regression
- add a dedicated CI gate for the fingerprint contract

## Scope
Regression infrastructure only. No statutory rates, exemptions, contribution percentages, or population-specific legal treatments are introduced.

## Validation
The golden hash is derived from the canonical JSON payload and Decimal normalization. GitHub Actions is the final execution authority for the full test suite.