### PR TITLE
feat: add versioned golden case repository

### DIFF
--- a/.github/workflows/golden-case-repository-gate.yml
+++ b/.github/workflows/golden-case-repository-gate.yml
@@ -1,0 +1,21 @@
+name: Golden Case Repository Gate
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golden-case-repository-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff check src/morva/rules/regression_cases.py tests/test_regression_cases.py
+      - run: pytest -q tests/test_regression_cases.py

--- a/docs/legal/golden-cases/1405.1/cases.json
+++ b/docs/legal/golden-cases/1405.1/cases.json
@@ -1,0 +1,62 @@
+[
+  {
+    "case_id": "1405-TAX-BASELINE-001",
+    "rule_pack_version": "1405.1",
+    "component_code": "TAX",
+    "population_scope": "all",
+    "effective_date": "1405-01-01",
+    "status": "review_required",
+    "input_values": {},
+    "expected_output": null,
+    "input_fingerprint": null,
+    "expected_output_fingerprint": null
+  },
+  {
+    "case_id": "1405-PENSION-BASELINE-001",
+    "rule_pack_version": "1405.1",
+    "component_code": "PENSION",
+    "population_scope": "all",
+    "effective_date": "1405-01-01",
+    "status": "review_required",
+    "input_values": {},
+    "expected_output": null,
+    "input_fingerprint": null,
+    "expected_output_fingerprint": null
+  },
+  {
+    "case_id": "1405-INSURANCE-BASELINE-001",
+    "rule_pack_version": "1405.1",
+    "component_code": "INSURANCE",
+    "population_scope": "all",
+    "effective_date": "1405-01-01",
+    "status": "review_required",
+    "input_values": {},
+    "expected_output": null,
+    "input_fingerprint": null,
+    "expected_output_fingerprint": null
+  },
+  {
+    "case_id": "1405-LOAN-BASELINE-001",
+    "rule_pack_version": "1405.1",
+    "component_code": "LOAN",
+    "population_scope": "all",
+    "effective_date": "1405-01-01",
+    "status": "review_required",
+    "input_values": {},
+    "expected_output": null,
+    "input_fingerprint": null,
+    "expected_output_fingerprint": null
+  },
+  {
+    "case_id": "1405-COURT_ORDER-BASELINE-001",
+    "rule_pack_version": "1405.1",
+    "component_code": "COURT_ORDER",
+    "population_scope": "all",
+    "effective_date": "1405-01-01",
+    "status": "review_required",
+    "input_values": {},
+    "expected_output": null,
+    "input_fingerprint": null,
+    "expected_output_fingerprint": null
+  }
+]

--- a/src/morva/rules/calculation_matrix.py
+++ b/src/morva/rules/calculation_matrix.py
@@ -12,12 +12,14 @@ from morva.audit.persistence import append_audit_event
 from morva.persistence.calculation_matrix_records import CalculationMatrixRecord
 from morva.persistence.enterprise_models import LegalSourceRecord, RuleEvidenceRecord
 from morva.security.policy import require_distinct_actors
+from morva.rules.regression_cases import validate_repository
 from morva.rules.rule_pack_1405 import REQUIRED_1405_COMPONENTS, is_1405_rule_pack
 
 _HEX64 = re.compile(r"^[0-9a-fA-F]{64}$")
 _ALLOWED_OPS = {"const", "value", "add", "sub", "mul", "div", "min", "max"}
 _TREATMENTS = {"earning", "deduction", "informational"}
 _REQUIRED_TREATMENT_FLAGS = {"taxable", "pensionable", "insurable"}
+_REGRESSION_COMPONENTS_1405 = ("TAX", "PENSION", "INSURANCE", "LOAN", "COURT_ORDER")
 
 
 @dataclass(frozen=True, slots=True)
@@ -104,6 +106,7 @@ def matrix_readiness(session: Session, rule_pack_version: str) -> MatrixReadines
     if is_1405_rule_pack(rule_pack_version):
         missing = [code for code in REQUIRED_1405_COMPONENTS if code not in component_codes]
         blockers.extend(f"missing required 1405 matrix component {code}" for code in missing)
+        blockers.extend(validate_repository(rule_pack_version, required_components=_REGRESSION_COMPONENTS_1405))
     for entry in entries:
         source = session.get(LegalSourceRecord, entry.legal_source_id)
         evidence = session.scalar(

--- a/src/morva/rules/regression_cases.py
+++ b/src/morva/rules/regression_cases.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Mapping
+
+from .regression import fingerprint_rule_result, fingerprint_values
+from .rule_pack_1405 import REQUIRED_1405_COMPONENTS
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[3] / "docs" / "legal" / "golden-cases"
+_ALLOWED_STATUSES = {"review_required", "approved", "published"}
+
+
+@dataclass(frozen=True, slots=True)
+class RegressionCase:
+    case_id: str
+    rule_pack_version: str
+    component_code: str
+    population_scope: str
+    effective_date: str
+    status: str
+    input_values: Mapping[str, Decimal]
+    expected_output: Mapping[str, object] | None
+    input_fingerprint: str | None
+    expected_output_fingerprint: str | None
+
+
+def _canonical_case(case: RegressionCase) -> dict[str, object]:
+    return {
+        "case_id": case.case_id,
+        "rule_pack_version": case.rule_pack_version,
+        "component_code": case.component_code,
+        "population_scope": case.population_scope,
+        "effective_date": case.effective_date,
+        "status": case.status,
+        "input_values": {key: format(Decimal(value), "f") for key, value in sorted(case.input_values.items())},
+        "expected_output": case.expected_output,
+        "input_fingerprint": case.input_fingerprint,
+        "expected_output_fingerprint": case.expected_output_fingerprint,
+    }
+
+
+def load_cases(rule_pack_version: str) -> tuple[RegressionCase, ...]:
+    path = _REPOSITORY_ROOT / rule_pack_version / "cases.json"
+    if not path.is_file():
+        return ()
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        raise ValueError("golden case repository must contain a JSON list")
+    cases: list[RegressionCase] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("golden regression cases must be JSON objects")
+        values = item.get("input_values", {})
+        if not isinstance(values, dict):
+            raise ValueError("input_values must be an object")
+        cases.append(
+            RegressionCase(
+                case_id=str(item["case_id"]),
+                rule_pack_version=str(item["rule_pack_version"]),
+                component_code=str(item["component_code"]),
+                population_scope=str(item["population_scope"]),
+                effective_date=str(item["effective_date"]),
+                status=str(item["status"]),
+                input_values={key: Decimal(str(value)) for key, value in values.items()},
+                expected_output=item.get("expected_output"),
+                input_fingerprint=item.get("input_fingerprint"),
+                expected_output_fingerprint=item.get("expected_output_fingerprint"),
+            )
+        )
+    return tuple(cases)
+
+
+def regression_suite_hash(rule_pack_version: str) -> str:
+    cases = load_cases(rule_pack_version)
+    canonical = [_canonical_case(case) for case in cases]
+    payload = json.dumps(canonical, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def validate_repository(rule_pack_version: str, *, required_components: tuple[str, ...] = ()) -> tuple[str, ...]:
+    cases = load_cases(rule_pack_version)
+    blockers: list[str] = []
+    required = required_components or REQUIRED_1405_COMPONENTS
+    by_component = {case.component_code: case for case in cases}
+    for component in required:
+        case = by_component.get(component)
+        if case is None:
+            blockers.append(f"missing golden regression case for component {component}")
+            continue
+        if case.rule_pack_version != rule_pack_version:
+            blockers.append(f"golden case {case.case_id} has a mismatched rule-pack version")
+        if case.status not in _ALLOWED_STATUSES:
+            blockers.append(f"golden case {case.case_id} has an invalid status")
+        if case.status not in {"approved", "published"}:
+            blockers.append(f"golden case {case.case_id} is not approved")
+        if not case.population_scope.strip():
+            blockers.append(f"golden case {case.case_id} requires population_scope")
+        if not case.input_values:
+            blockers.append(f"golden case {case.case_id} has no governed input values")
+        elif case.input_fingerprint is None:
+            blockers.append(f"golden case {case.case_id} is missing input_fingerprint")
+        elif fingerprint_values(case.input_values) != case.input_fingerprint:
+            blockers.append(f"golden case {case.case_id} input fingerprint mismatch")
+        if case.expected_output is None:
+            blockers.append(f"golden case {case.case_id} is missing expected output")
+        if not case.expected_output_fingerprint:
+            blockers.append(f"golden case {case.case_id} is missing expected output fingerprint")
+    return tuple(blockers)
+
+
+def verify_expected_result(case: RegressionCase, actual_result: object) -> None:
+    if case.expected_output_fingerprint is None:
+        raise ValueError(f"golden case {case.case_id} has no expected output fingerprint")
+    actual = fingerprint_rule_result(actual_result)
+    if actual != case.expected_output_fingerprint:
+        raise ValueError(f"golden case {case.case_id} output fingerprint mismatch")

--- a/tests/test_regression_cases.py
+++ b/tests/test_regression_cases.py
@@ -1,0 +1,17 @@
+from morva.rules.regression_cases import load_cases, regression_suite_hash, validate_repository
+
+
+def test_1405_golden_repository_has_five_core_cases():
+    cases = load_cases("1405.1")
+    assert {case.component_code for case in cases} == {"TAX", "PENSION", "INSURANCE", "LOAN", "COURT_ORDER"}
+    assert all(case.rule_pack_version == "1405.1" for case in cases)
+    assert regression_suite_hash("1405.1") == "40713034bc6f1004c6eab332f066cd4312584ea8a214f03ecaa5ace0d00482d6"
+
+
+def test_1405_golden_repository_fails_closed_until_authoritative_cases_exist():
+    blockers = validate_repository(
+        "1405.1",
+        required_components=("TAX", "PENSION", "INSURANCE", "LOAN", "COURT_ORDER"),
+    )
+    assert len(blockers) >= 20
+    assert all("not approved" in blocker or "missing" in blocker or "no governed" in blocker for blocker in blockers)


### PR DESCRIPTION
Adds a versioned Golden Case Repository for the five governed legal components and connects 1405 calculation-matrix readiness to fail-closed golden-case validation.

- Adds typed loader/validation and deterministic suite hashing.
- Registers 1405.1 baseline placeholders for TAX, PENSION, INSURANCE, LOAN, COURT_ORDER.
- Blocks 1405 matrix readiness until cases have governed inputs, expected outputs/fingerprints, and approved status.
- Adds a dedicated CI gate.
- Does not assert statutory rates, thresholds, or legal treatments.