### PR TITLE
feat: bind golden cases to authoritative evidence

### DIFF
--- a/.github/workflows/golden-case-repository-gate.yml
+++ b/.github/workflows/golden-case-repository-gate.yml
@@ -17,5 +17,5 @@ jobs:
           python-version: "3.12"
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -e '.[dev]'
-      - run: ruff check src/morva/rules/regression_cases.py tests/test_regression_cases.py
-      - run: pytest -q tests/test_regression_cases.py
+      - run: ruff check src/morva/rules/regression_cases.py src/morva/rules/calculation_matrix.py tests/test_regression_cases.py
+      - run: pytest -q tests/test_regression_cases.py tests/test_calculation_matrix.py

--- a/docs/legal/golden-cases/1405.1/cases.json
+++ b/docs/legal/golden-cases/1405.1/cases.json
@@ -1,62 +1,7 @@
 [
-  {
-    "case_id": "1405-TAX-BASELINE-001",
-    "rule_pack_version": "1405.1",
-    "component_code": "TAX",
-    "population_scope": "all",
-    "effective_date": "1405-01-01",
-    "status": "review_required",
-    "input_values": {},
-    "expected_output": null,
-    "input_fingerprint": null,
-    "expected_output_fingerprint": null
-  },
-  {
-    "case_id": "1405-PENSION-BASELINE-001",
-    "rule_pack_version": "1405.1",
-    "component_code": "PENSION",
-    "population_scope": "all",
-    "effective_date": "1405-01-01",
-    "status": "review_required",
-    "input_values": {},
-    "expected_output": null,
-    "input_fingerprint": null,
-    "expected_output_fingerprint": null
-  },
-  {
-    "case_id": "1405-INSURANCE-BASELINE-001",
-    "rule_pack_version": "1405.1",
-    "component_code": "INSURANCE",
-    "population_scope": "all",
-    "effective_date": "1405-01-01",
-    "status": "review_required",
-    "input_values": {},
-    "expected_output": null,
-    "input_fingerprint": null,
-    "expected_output_fingerprint": null
-  },
-  {
-    "case_id": "1405-LOAN-BASELINE-001",
-    "rule_pack_version": "1405.1",
-    "component_code": "LOAN",
-    "population_scope": "all",
-    "effective_date": "1405-01-01",
-    "status": "review_required",
-    "input_values": {},
-    "expected_output": null,
-    "input_fingerprint": null,
-    "expected_output_fingerprint": null
-  },
-  {
-    "case_id": "1405-COURT_ORDER-BASELINE-001",
-    "rule_pack_version": "1405.1",
-    "component_code": "COURT_ORDER",
-    "population_scope": "all",
-    "effective_date": "1405-01-01",
-    "status": "review_required",
-    "input_values": {},
-    "expected_output": null,
-    "input_fingerprint": null,
-    "expected_output_fingerprint": null
-  }
+  {"case_id":"1405-TAX-BASELINE-001","rule_pack_version":"1405.1","component_code":"TAX","population_scope":"all","effective_date":"1405-01-01","status":"review_required","input_values":{},"expected_output":null,"input_fingerprint":null,"expected_output_fingerprint":null,"legal_source_hash":"0000000000000000000000000000000000000000000000000000000000000000","legal_article":null,"legal_clause":null},
+  {"case_id":"1405-PENSION-BASELINE-001","rule_pack_version":"1405.1","component_code":"PENSION","population_scope":"all","effective_date":"1405-01-01","status":"review_required","input_values":{},"expected_output":null,"input_fingerprint":null,"expected_output_fingerprint":null,"legal_source_hash":"0000000000000000000000000000000000000000000000000000000000000000","legal_article":null,"legal_clause":null},
+  {"case_id":"1405-INSURANCE-BASELINE-001","rule_pack_version":"1405.1","component_code":"INSURANCE","population_scope":"all","effective_date":"1405-01-01","status":"review_required","input_values":{},"expected_output":null,"input_fingerprint":null,"expected_output_fingerprint":null,"legal_source_hash":"0000000000000000000000000000000000000000000000000000000000000000","legal_article":null,"legal_clause":null},
+  {"case_id":"1405-LOAN-BASELINE-001","rule_pack_version":"1405.1","component_code":"LOAN","population_scope":"all","effective_date":"1405-01-01","status":"review_required","input_values":{},"expected_output":null,"input_fingerprint":null,"expected_output_fingerprint":null,"legal_source_hash":"0000000000000000000000000000000000000000000000000000000000000000","legal_article":null,"legal_clause":null},
+  {"case_id":"1405-COURT_ORDER-BASELINE-001","rule_pack_version":"1405.1","component_code":"COURT_ORDER","population_scope":"all","effective_date":"1405-01-01","status":"review_required","input_values":{},"expected_output":null,"input_fingerprint":null,"expected_output_fingerprint":null,"legal_source_hash":"0000000000000000000000000000000000000000000000000000000000000000","legal_article":null,"legal_clause":null}
 ]

--- a/src/morva/rules/calculation_matrix.py
+++ b/src/morva/rules/calculation_matrix.py
@@ -12,7 +12,7 @@ from morva.audit.persistence import append_audit_event
 from morva.persistence.calculation_matrix_records import CalculationMatrixRecord
 from morva.persistence.enterprise_models import LegalSourceRecord, RuleEvidenceRecord
 from morva.security.policy import require_distinct_actors
-from morva.rules.regression_cases import validate_repository
+from morva.rules.regression_cases import validate_repository_against_evidence
 from morva.rules.rule_pack_1405 import REQUIRED_1405_COMPONENTS, is_1405_rule_pack
 
 _HEX64 = re.compile(r"^[0-9a-fA-F]{64}$")
@@ -55,19 +55,7 @@ def _validate_expression(node: object) -> None:
         _validate_expression(child)
 
 
-def validate_matrix_payload(
-    *,
-    treatment: str,
-    effective_from: date,
-    effective_to: date | None,
-    regression_suite_hash: str,
-    expression: dict[str, object],
-    legal_article: str,
-    population_scope: str,
-    taxable: object | None = None,
-    pensionable: object | None = None,
-    insurable: object | None = None,
-) -> None:
+def validate_matrix_payload(*, treatment: str, effective_from: date, effective_to: date | None, regression_suite_hash: str, expression: dict[str, object], legal_article: str, population_scope: str, taxable: object | None = None, pensionable: object | None = None, insurable: object | None = None) -> None:
     if treatment not in _TREATMENTS:
         raise ValueError("treatment must be earning, deduction or informational")
     if effective_to is not None and effective_to < effective_from:
@@ -96,9 +84,7 @@ def approve_matrix_entry(entry: CalculationMatrixRecord, approver_id: str) -> No
 
 
 def matrix_readiness(session: Session, rule_pack_version: str) -> MatrixReadiness:
-    entries = session.scalars(
-        select(CalculationMatrixRecord).where(CalculationMatrixRecord.rule_pack_version == rule_pack_version)
-    ).all()
+    entries = session.scalars(select(CalculationMatrixRecord).where(CalculationMatrixRecord.rule_pack_version == rule_pack_version)).all()
     blockers: list[str] = []
     component_codes = {entry.component_code for entry in entries}
     if not entries:
@@ -106,15 +92,10 @@ def matrix_readiness(session: Session, rule_pack_version: str) -> MatrixReadines
     if is_1405_rule_pack(rule_pack_version):
         missing = [code for code in REQUIRED_1405_COMPONENTS if code not in component_codes]
         blockers.extend(f"missing required 1405 matrix component {code}" for code in missing)
-        blockers.extend(validate_repository(rule_pack_version, required_components=_REGRESSION_COMPONENTS_1405))
+        blockers.extend(validate_repository_against_evidence(session, rule_pack_version, required_components=_REGRESSION_COMPONENTS_1405))
     for entry in entries:
         source = session.get(LegalSourceRecord, entry.legal_source_id)
-        evidence = session.scalar(
-            select(RuleEvidenceRecord).where(
-                RuleEvidenceRecord.rule_pack_version == entry.rule_pack_version,
-                RuleEvidenceRecord.component_code == entry.component_code,
-            )
-        )
+        evidence = session.scalar(select(RuleEvidenceRecord).where(RuleEvidenceRecord.rule_pack_version == entry.rule_pack_version, RuleEvidenceRecord.component_code == entry.component_code))
         if source is None:
             blockers.append(f"missing legal source for component {entry.component_code}")
             continue
@@ -152,12 +133,7 @@ def create_matrix_entry(session: Session, payload: dict[str, object], actor_id: 
     source = session.get(LegalSourceRecord, legal_source_id)
     if source is None:
         raise ValueError("legal source not found")
-    evidence = session.scalar(
-        select(RuleEvidenceRecord).where(
-            RuleEvidenceRecord.rule_pack_version == version,
-            RuleEvidenceRecord.component_code == component,
-        )
-    )
+    evidence = session.scalar(select(RuleEvidenceRecord).where(RuleEvidenceRecord.rule_pack_version == version, RuleEvidenceRecord.component_code == component))
     if evidence is None:
         raise ValueError("rule evidence must be registered before calculation-matrix entry")
     if source.status not in {"approved", "published"} or evidence.status not in {"approved", "published"}:
@@ -175,28 +151,9 @@ def create_matrix_entry(session: Session, payload: dict[str, object], actor_id: 
     missing_flags = sorted(_REQUIRED_TREATMENT_FLAGS - payload.keys())
     if missing_flags:
         raise ValueError(f"explicit treatment flags are required: {missing_flags}")
-    validate_matrix_payload(
-        treatment=str(payload["treatment"]),
-        effective_from=payload["effective_from"],
-        effective_to=payload.get("effective_to"),
-        regression_suite_hash=str(payload["regression_suite_hash"]),
-        expression=payload["expression"],
-        legal_article=str(payload["legal_article"]),
-        population_scope=population,
-        taxable=payload["taxable"],
-        pensionable=payload["pensionable"],
-        insurable=payload["insurable"],
-    )
+    validate_matrix_payload(treatment=str(payload["treatment"]), effective_from=payload["effective_from"], effective_to=payload.get("effective_to"), regression_suite_hash=str(payload["regression_suite_hash"]), expression=payload["expression"], legal_article=str(payload["legal_article"]), population_scope=population, taxable=payload["taxable"], pensionable=payload["pensionable"], insurable=payload["insurable"])
     entry = CalculationMatrixRecord(**payload)
     session.add(entry)
     session.flush()
-    append_audit_event(
-        event_type="rule.matrix.created",
-        entity_type="calculation_matrix",
-        entity_id=str(entry.id),
-        actor_id=actor_id,
-        payload={"rule_pack_version": version, "component_code": component, "population_scope": population},
-        reason="register calculation matrix entry",
-        session=session,
-    )
+    append_audit_event(event_type="rule.matrix.created", entity_type="calculation_matrix", entity_id=str(entry.id), actor_id=actor_id, payload={"rule_pack_version": version, "component_code": component, "population_scope": population}, reason="register calculation matrix entry", session=session)
     return entry

--- a/src/morva/rules/regression_cases.py
+++ b/src/morva/rules/regression_cases.py
@@ -7,11 +7,17 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Mapping
 
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from morva.persistence.enterprise_models import LegalSourceRecord, RuleEvidenceRecord
+
 from .regression import fingerprint_rule_result, fingerprint_values
 from .rule_pack_1405 import REQUIRED_1405_COMPONENTS
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[3] / "docs" / "legal" / "golden-cases"
 _ALLOWED_STATUSES = {"review_required", "approved", "published"}
+_HEX64 = set("0123456789abcdefABCDEF")
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,6 +32,9 @@ class RegressionCase:
     expected_output: Mapping[str, object] | None
     input_fingerprint: str | None
     expected_output_fingerprint: str | None
+    legal_source_hash: str | None
+    legal_article: str | None
+    legal_clause: str | None
 
 
 def _canonical_case(case: RegressionCase) -> dict[str, object]:
@@ -40,6 +49,9 @@ def _canonical_case(case: RegressionCase) -> dict[str, object]:
         "expected_output": case.expected_output,
         "input_fingerprint": case.input_fingerprint,
         "expected_output_fingerprint": case.expected_output_fingerprint,
+        "legal_source_hash": case.legal_source_hash,
+        "legal_article": case.legal_article,
+        "legal_clause": case.legal_clause,
     }
 
 
@@ -69,6 +81,9 @@ def load_cases(rule_pack_version: str) -> tuple[RegressionCase, ...]:
                 expected_output=item.get("expected_output"),
                 input_fingerprint=item.get("input_fingerprint"),
                 expected_output_fingerprint=item.get("expected_output_fingerprint"),
+                legal_source_hash=item.get("legal_source_hash"),
+                legal_article=item.get("legal_article"),
+                legal_clause=item.get("legal_clause"),
             )
         )
     return tuple(cases)
@@ -109,6 +124,55 @@ def validate_repository(rule_pack_version: str, *, required_components: tuple[st
             blockers.append(f"golden case {case.case_id} is missing expected output")
         if not case.expected_output_fingerprint:
             blockers.append(f"golden case {case.case_id} is missing expected output fingerprint")
+        if not case.legal_source_hash:
+            blockers.append(f"golden case {case.case_id} is missing legal_source_hash")
+        elif len(case.legal_source_hash) != 64 or not set(case.legal_source_hash) <= _HEX64:
+            blockers.append(f"golden case {case.case_id} has an invalid legal_source_hash")
+        if not case.legal_article or not case.legal_article.strip():
+            blockers.append(f"golden case {case.case_id} is missing legal_article")
+    return tuple(blockers)
+
+
+def validate_repository_against_evidence(
+    session: Session,
+    rule_pack_version: str,
+    *,
+    required_components: tuple[str, ...] = (),
+) -> tuple[str, ...]:
+    blockers = list(validate_repository(rule_pack_version, required_components=required_components))
+    required = required_components or REQUIRED_1405_COMPONENTS
+    cases = {case.component_code: case for case in load_cases(rule_pack_version)}
+    for component in required:
+        case = cases.get(component)
+        if case is None:
+            continue
+        evidence = session.scalar(
+            select(RuleEvidenceRecord).where(
+                RuleEvidenceRecord.rule_pack_version == rule_pack_version,
+                RuleEvidenceRecord.component_code == component,
+            )
+        )
+        if evidence is None:
+            blockers.append(f"missing rule evidence for golden case {case.case_id}")
+            continue
+        source = session.get(LegalSourceRecord, evidence.legal_source_id)
+        if source is None:
+            blockers.append(f"missing legal source for golden case {case.case_id}")
+            continue
+        if case.legal_source_hash and case.legal_source_hash != evidence.source_hash:
+            blockers.append(f"golden case {case.case_id} source hash mismatch")
+        if case.legal_source_hash and case.legal_source_hash != source.document_hash:
+            blockers.append(f"golden case {case.case_id} legal source hash mismatch")
+        if case.legal_article and case.legal_article.strip() != evidence.article.strip():
+            blockers.append(f"golden case {case.case_id} article mismatch")
+        if (case.legal_clause or "").strip() != (evidence.clause or "").strip():
+            blockers.append(f"golden case {case.case_id} clause mismatch")
+        if case.population_scope.strip() != evidence.population_scope.strip():
+            blockers.append(f"golden case {case.case_id} population scope mismatch")
+        if evidence.status not in {"approved", "published"}:
+            blockers.append(f"rule evidence for golden case {case.case_id} is not approved")
+        if source.status not in {"approved", "published"}:
+            blockers.append(f"legal source for golden case {case.case_id} is not approved")
     return tuple(blockers)
 
 

--- a/tests/test_regression_cases.py
+++ b/tests/test_regression_cases.py
@@ -1,17 +1,68 @@
-from morva.rules.regression_cases import load_cases, regression_suite_hash, validate_repository
+from datetime import datetime
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from morva.persistence.enterprise_models import LegalSourceRecord, RuleEvidenceRecord
+from morva.persistence.models import Base
+from morva.rules.regression_cases import (
+    load_cases,
+    regression_suite_hash,
+    validate_repository,
+    validate_repository_against_evidence,
+)
+
+
+def _session():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)()
 
 
 def test_1405_golden_repository_has_five_core_cases():
     cases = load_cases("1405.1")
     assert {case.component_code for case in cases} == {"TAX", "PENSION", "INSURANCE", "LOAN", "COURT_ORDER"}
     assert all(case.rule_pack_version == "1405.1" for case in cases)
-    assert regression_suite_hash("1405.1") == "40713034bc6f1004c6eab332f066cd4312584ea8a214f03ecaa5ace0d00482d6"
+    assert regression_suite_hash("1405.1") == "efad8788dd84eaae67dc8034361a92e2b31010fa7be096358ace7520c63e5631"
 
 
 def test_1405_golden_repository_fails_closed_until_authoritative_cases_exist():
-    blockers = validate_repository(
-        "1405.1",
-        required_components=("TAX", "PENSION", "INSURANCE", "LOAN", "COURT_ORDER"),
-    )
-    assert len(blockers) >= 20
-    assert all("not approved" in blocker or "missing" in blocker or "no governed" in blocker for blocker in blockers)
+    blockers = validate_repository("1405.1", required_components=("TAX", "PENSION", "INSURANCE", "LOAN", "COURT_ORDER"))
+    assert len(blockers) >= 25
+    assert all("not approved" in blocker or "missing" in blocker or "no governed" in blocker or "invalid" in blocker for blocker in blockers)
+
+
+def test_1405_golden_repository_must_match_registered_legal_evidence():
+    with _session() as session:
+        source = LegalSourceRecord(
+            citation="Synthetic authority source",
+            issuer="Synthetic issuer",
+            adoption_date="2026-01-01",
+            effective_from="2026-01-01",
+            document_hash="a" * 64,
+            status="approved",
+        )
+        session.add(source)
+        session.flush()
+        for component in ("TAX", "PENSION", "INSURANCE", "LOAN", "COURT_ORDER"):
+            session.add(
+                RuleEvidenceRecord(
+                    rule_pack_version="1405.1",
+                    component_code=component,
+                    legal_source_id=source.id,
+                    issuer=source.issuer,
+                    article="1",
+                    clause=None,
+                    population_scope="all",
+                    source_hash=source.document_hash,
+                    regression_suite_hash=regression_suite_hash("1405.1"),
+                    status="approved",
+                    reviewed_by="reviewer",
+                    approved_by="approver",
+                    approved_at=datetime(2026, 1, 3),
+                )
+            )
+        session.commit()
+        blockers = validate_repository_against_evidence(session, "1405.1", required_components=("TAX", "PENSION", "INSURANCE", "LOAN", "COURT_ORDER"))
+        assert any("source hash mismatch" in blocker for blocker in blockers)
+        assert any("missing legal_article" in blocker for blocker in blockers)


### PR DESCRIPTION
Connects the versioned Golden Case Repository to the governed legal-evidence chain and calculation-matrix readiness.

- Requires source hash and legal article binding metadata on every required 1405 Golden Case.
- Validates Golden Case bindings against RuleEvidenceRecord and LegalSourceRecord.
- Makes 1405 matrix readiness fail closed on missing/mismatched evidence bindings.
- Extends the existing Golden Case CI gate to cover evidence binding and calculation-matrix tests.
- Keeps current 1405 cases synthetic/review_required; no statutory rates or treatments are asserted.