### PR TITLE
feat: add snapshot-driven retro and historical replay guards

### DIFF
--- a/.github/workflows/m3-13-snapshot-retro-replay.yml
+++ b/.github/workflows/m3-13-snapshot-retro-replay.yml
@@ -1,0 +1,22 @@
+name: M3.13 Snapshot Retro Replay Gate
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  m3-13-snapshot-retro-replay-gate:
+    name: M3.13 snapshot-driven retro/replay gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[dev]'
+      - run: ruff check src/morva/payroll/retro.py src/morva/payroll/replay.py tests/test_m3_13_snapshot_retro_replay.py
+      - run: pytest -q tests/test_m3_13_snapshot_retro_replay.py

--- a/docs/IMPLEMENTATION_MATRIX.md
+++ b/docs/IMPLEMENTATION_MATRIX.md
@@ -11,7 +11,7 @@
 | 5 | 1405 Rule Pack | governed lifecycle foundation; remains `review_required` until authoritative legal/finance approval |
 | 6 | Tax / Pension / Insurance | persisted ledger foundations plus explicit fail-closed treatment governance for `taxable/pensionable/insurable`; approved population-specific rule sets and primary-source evidence pending |
 | 7 | High-volume Payroll | batch/chunk foundations; target-scale execution evidence pending |
-| 8 | Retro + Jalali | deterministic period/replay foundations; complete snapshot-driven retro pending |
+| 8 | Retro + Jalali | immutable PersonnelSnapshot persistence + deterministic snapshot-driven retro reconciliation + snapshot-bound historical replay guard implemented; complete historical replay corpus and certification pending |
 | 9 | Loans / Debts / Deductions | persisted loan and deduction ledger foundations plus explicit fail-closed treatment governance; authoritative ledgers/policies pending |
 | 10 | Approval / SoD | permission + privileged + distinct-actor controls implemented for personnel-order decisions; durable enterprise IAM workflow pending |
 | 11 | SINA Adapter | fail-closed typed contract; official schema/endpoint/credential and staging evidence required |
@@ -29,7 +29,7 @@
 | 23 | Real Payroll Reconciliation | reconciliation foundations; authoritative three-way production certification pending |
 | 24 | Persistent Payroll Artifacts | implemented; employee-level deterministic result and payslip-line persistence |
 | 25 | Transactional Integration Messaging | implemented foundation; official provider delivery and acknowledgement pending |
-| 26 | Historical Payroll Replay | implemented foundation; production legal-rule replay certification pending |
+| 26 | Historical Payroll Replay | snapshot-bound deterministic replay guard implemented; production legal-rule replay certification pending |
 | 27 | Core HR Employee Profile API | implemented read APIs for employee, employment, assignment, education, experience and dependents; automated API coverage added; production master-data validation pending |
 | 28 | Core HR Effective Snapshots | implemented immutable period snapshot creation/read API with deterministic content hash; payroll/order population integration and production master-data evidence pending |
 
@@ -52,6 +52,10 @@ Each executable component mapping is required to bind a Rule Pack and population
 ## Ledger Treatment Governance
 
 `TAX`, `PENSION`, `INSURANCE`, `LOAN` and `COURT_ORDER` now have an explicit treatment-governance boundary. Classification flags are explicit rather than inferred, and approval requires primary-source metadata, effective dates, independent review/approval and regression evidence. Missing approval leaves execution fail-closed. This does not constitute legal approval or populate rates/thresholds.
+
+## Snapshot-Driven Retro / Historical Replay Governance
+
+M3.13 binds historical payroll evidence to the immutable `PersonnelSnapshotRecord` for the applicable employee and period. Replay fails closed when the snapshot is missing, has a different employee/period, or its hash differs from the payroll artifact. Retroactive reconciliation requires original and revised persisted artifacts for every period and requires both artifacts to reference the same immutable snapshot; current HR state is never substituted silently. Legal rates/formulas are not inferred or activated by this boundary.
 
 ## Release position
 

--- a/docs/M3_13_SNAPSHOT_RETRO_REPLAY.md
+++ b/docs/M3_13_SNAPSHOT_RETRO_REPLAY.md
@@ -1,0 +1,29 @@
+# M3.13 — Snapshot-Driven Retroactive Recalculation & Historical Replay
+
+## Scope
+
+M3.13 hardens the historical payroll boundary around the immutable `PersonnelSnapshotRecord` already present in Morva. A historical payroll artifact must be replayable only when its employee, period and snapshot identity/hash remain consistent with the persisted snapshot.
+
+Retroactive reconciliation now requires a persisted original artifact and revised artifact for every requested period. Both artifacts must reference the **same immutable personnel snapshot** for that period. Their persisted net outputs are compared deterministically; no current HR state, current personnel record, or unapproved legal rule is substituted silently.
+
+## Fail-closed invariants
+
+1. Missing historical snapshot blocks replay and retroactive reconciliation.
+2. Snapshot employee/period mismatch blocks replay and retroactive reconciliation.
+3. Snapshot hash mismatch blocks replay and retroactive reconciliation.
+4. A retro period missing either the original or revised persisted artifact is rejected.
+5. Original and revised artifacts for a historical period must share one immutable snapshot.
+6. Period keys are validated as `YYYY-MM` with months `01..12`.
+7. No legal rate, threshold or formula is inferred or activated by M3.13.
+
+## Historical replay
+
+`replay_artifact()` now proves snapshot provenance before reconstructing the persisted payslip lines and recalculating the fingerprint/output hash. The returned evidence includes the historical snapshot id/hash and rule-pack version.
+
+## Snapshot-driven retro
+
+`calculate_snapshot_driven_retro()` is a provenance/reconciliation boundary over persisted payroll artifacts. It intentionally consumes persisted original/revised outputs rather than recalculating against today's personnel state. The resulting periods retain both artifact snapshot ids and rule-pack versions for auditability.
+
+## Certification boundary
+
+This tranche provides deterministic software controls and tests. It does **not** certify any legal payroll treatment, activate rates/formulas, or constitute production historical replay certification. A certified historical replay corpus still requires authoritative legal-rule evidence, approved population-specific rule packs, representative historical data, and independent finance/legal validation.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,6 +23,7 @@
 - CI for Python 3.12/3.13, PostgreSQL, migrations, Ruff, pytest, dependency audit and web build
 - Living implementation, production-readiness and prompt-compliance documentation
 - M3.12 ledger treatment governance boundary with explicit fail-closed classification and approval evidence requirements
+- M3.13 snapshot-driven retro/replay provenance boundary with immutable historical snapshot binding and dedicated CI gate
 
 ## Current execution queue
 
@@ -32,7 +33,7 @@
 4. Complete personnel-order lifecycle and approval evidence.
 5. Complete legal component matrix and annual Rule Packs from primary sources.
 6. Complete tax, pension, insurance, loans and judicial-deduction ledgers with approved treatments. **M3.12 governance boundary is implemented; authoritative treatment evidence and approved population-specific rules remain pending.**
-7. Complete snapshot-driven retroactive recalculation and certified historical replay corpus.
+7. Complete snapshot-driven retroactive recalculation and certified historical replay corpus. **M3.13 software provenance/reconciliation controls are implemented; authoritative historical replay corpus and certification evidence remain pending.**
 8. Remove remaining demonstration-only frontend behavior and wire operational views to authenticated APIs.
 9. Complete employee self-service, objection/case management and production PDF/reporting.
 10. Implement official SINA, accounting, treasury, bank, tax and insurance adapters only from authoritative contracts.

--- a/src/morva/payroll/replay.py
+++ b/src/morva/payroll/replay.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from morva.persistence.enterprise_models import PayrollArtifactRecord, PayslipLineRecord
+from morva.persistence.models import PersonnelSnapshotRecord
 from morva.payroll import PayrollCalculator, PayrollLine
 
 
@@ -16,10 +17,23 @@ class ReplayMismatch(RuntimeError):
     pass
 
 
+def _validate_snapshot(session: Session, artifact: PayrollArtifactRecord) -> PersonnelSnapshotRecord:
+    snapshot = session.get(PersonnelSnapshotRecord, artifact.personnel_snapshot_id)
+    if snapshot is None:
+        raise ReplayMismatch("historical personnel snapshot not found")
+    if snapshot.employee_no != artifact.employee_no or snapshot.effective_period != artifact.period:
+        raise ReplayMismatch("historical personnel snapshot identity does not match payroll artifact")
+    if snapshot.snapshot_hash != artifact.personnel_snapshot_hash:
+        raise ReplayMismatch("historical personnel snapshot hash does not match payroll artifact")
+    return snapshot
+
+
 def replay_artifact(session: Session, artifact_id: UUID) -> dict[str, object]:
     artifact = session.get(PayrollArtifactRecord, artifact_id)
     if artifact is None:
         raise ReplayMismatch("payroll artifact not found")
+    _validate_snapshot(session, artifact)
+
     rows = session.scalars(
         select(PayslipLineRecord)
         .where(PayslipLineRecord.artifact_id == artifact.id)
@@ -62,6 +76,9 @@ def replay_artifact(session: Session, artifact_id: UUID) -> dict[str, object]:
         "artifact_id": str(artifact.id),
         "employee_no": artifact.employee_no,
         "period": artifact.period,
+        "personnel_snapshot_id": str(artifact.personnel_snapshot_id),
+        "personnel_snapshot_hash": artifact.personnel_snapshot_hash,
+        "rule_pack_version": artifact.rule_pack_version,
         "matches": True,
         "output_hash": replay_hash,
         "gross": replay_output["gross"],

--- a/src/morva/payroll/retro.py
+++ b/src/morva/payroll/retro.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Mapping
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from morva.persistence.enterprise_models import PayrollArtifactRecord
+from morva.persistence.models import PersonnelSnapshotRecord
 
 
 @dataclass(frozen=True, slots=True)
@@ -10,6 +16,10 @@ class RetroPeriod:
     period: str
     old_net: Decimal
     new_net: Decimal
+    original_snapshot_id: UUID | None = None
+    revised_snapshot_id: UUID | None = None
+    original_rule_pack_version: str | None = None
+    revised_rule_pack_version: str | None = None
 
     @property
     def difference(self) -> Decimal:
@@ -28,6 +38,33 @@ class RetroResult:
     def net_difference(self) -> Decimal:
         return sum((item.difference for item in self.periods), Decimal(0))
 
+    @property
+    def snapshot_driven(self) -> bool:
+        return all(item.original_snapshot_id is not None and item.revised_snapshot_id is not None for item in self.periods)
+
+
+class RetroMismatch(RuntimeError):
+    """Raised when retroactive inputs cannot be proven snapshot-bound."""
+
+
+def _validate_period(period: str) -> None:
+    if len(period) != 7 or period[4] != "-" or not period[:4].isdigit() or not period[5:].isdigit():
+        raise RetroMismatch(f"invalid payroll period: {period!r}")
+    month = int(period[5:])
+    if month < 1 or month > 12:
+        raise RetroMismatch(f"invalid payroll period: {period!r}")
+
+
+def _validate_snapshot(session: Session, *, employee_no: str, period: str, artifact: PayrollArtifactRecord) -> PersonnelSnapshotRecord:
+    snapshot = session.get(PersonnelSnapshotRecord, artifact.personnel_snapshot_id)
+    if snapshot is None:
+        raise RetroMismatch(f"personnel snapshot not found for artifact {artifact.id}")
+    if snapshot.employee_no != employee_no or snapshot.effective_period != period:
+        raise RetroMismatch(f"personnel snapshot identity mismatch for artifact {artifact.id}")
+    if snapshot.snapshot_hash != artifact.personnel_snapshot_hash:
+        raise RetroMismatch(f"personnel snapshot hash mismatch for artifact {artifact.id}")
+    return snapshot
+
 
 def calculate_retroactive(old: Mapping[str, Decimal], new: Mapping[str, Decimal]) -> RetroResult:
     periods = tuple(
@@ -35,3 +72,59 @@ def calculate_retroactive(old: Mapping[str, Decimal], new: Mapping[str, Decimal]
         for period in sorted(set(old) | set(new))
     )
     return RetroResult(periods)
+
+
+def calculate_snapshot_driven_retro(
+    session: Session,
+    *,
+    employee_no: str,
+    original_artifacts: Mapping[str, UUID],
+    revised_artifacts: Mapping[str, UUID],
+) -> RetroResult:
+    """Compare persisted original/revised payroll artifacts after proving shared snapshot binding.
+
+    The original and revised calculations for a historical period must use the same immutable
+    personnel snapshot. Legal rates/formulas are never inferred or activated here; the function
+    only reconciles persisted artifact outputs and their provenance.
+    """
+    if not employee_no.strip():
+        raise RetroMismatch("employee number is required")
+    periods = sorted(set(original_artifacts) | set(revised_artifacts))
+    if not periods:
+        raise RetroMismatch("at least one retro period is required")
+
+    result: list[RetroPeriod] = []
+    for period in periods:
+        _validate_period(period)
+        original_id = original_artifacts.get(period)
+        revised_id = revised_artifacts.get(period)
+        if original_id is None or revised_id is None:
+            raise RetroMismatch(f"both original and revised artifacts are required for {period}")
+
+        original = session.get(PayrollArtifactRecord, original_id)
+        revised = session.get(PayrollArtifactRecord, revised_id)
+        if original is None or revised is None:
+            raise RetroMismatch(f"payroll artifact missing for {period}")
+        if original.employee_no != employee_no or revised.employee_no != employee_no:
+            raise RetroMismatch(f"payroll artifact employee mismatch for {period}")
+        if original.period != period or revised.period != period:
+            raise RetroMismatch(f"payroll artifact period mismatch for {period}")
+
+        original_snapshot = _validate_snapshot(session, employee_no=employee_no, period=period, artifact=original)
+        revised_snapshot = _validate_snapshot(session, employee_no=employee_no, period=period, artifact=revised)
+        if original_snapshot.id != revised_snapshot.id or original_snapshot.snapshot_hash != revised_snapshot.snapshot_hash:
+            raise RetroMismatch(f"original and revised artifacts must share one immutable personnel snapshot for {period}")
+
+        result.append(
+            RetroPeriod(
+                period=period,
+                old_net=Decimal(original.net),
+                new_net=Decimal(revised.net),
+                original_snapshot_id=original.personnel_snapshot_id,
+                revised_snapshot_id=revised.personnel_snapshot_id,
+                original_rule_pack_version=original.rule_pack_version,
+                revised_rule_pack_version=revised.rule_pack_version,
+            )
+        )
+
+    return RetroResult(tuple(result))

--- a/tests/test_m3_13_snapshot_retro_replay.py
+++ b/tests/test_m3_13_snapshot_retro_replay.py
@@ -1,7 +1,7 @@
-from uuid import uuid4
 from decimal import Decimal
 from hashlib import sha256
 import json
+from uuid import uuid4
 
 import pytest
 from sqlalchemy import create_engine
@@ -76,7 +76,6 @@ def test_replay_requires_historical_snapshot_and_hash() -> None:
     with Session(engine) as session:
         snapshot = _snapshot(session, "E-1", "1405-05", "frozen")
         artifact = _artifact(session, snapshot, run_marker="run", net="1000")
-        artifact.output_hash = _output_hash("E-1", "1405-05", "1000")
         session.add(
             PayslipLineRecord(
                 artifact_id=artifact.id,
@@ -88,6 +87,8 @@ def test_replay_requires_historical_snapshot_and_hash() -> None:
                 kind="earning",
             )
         )
+        session.flush()
+        artifact.output_hash = _output_hash("E-1", "1405-05", "1000.0000")
         session.commit()
         result = replay_artifact(session, artifact.id)
         assert result["matches"] is True

--- a/tests/test_m3_13_snapshot_retro_replay.py
+++ b/tests/test_m3_13_snapshot_retro_replay.py
@@ -1,0 +1,126 @@
+from uuid import uuid4
+from decimal import Decimal
+from hashlib import sha256
+import json
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from morva.persistence.enterprise_models import Base, PayrollArtifactRecord, PayslipLineRecord
+from morva.persistence.models import PersonnelSnapshotRecord
+from morva.payroll import PayrollCalculator, PayrollLine
+from morva.payroll.replay import ReplayMismatch, replay_artifact
+from morva.payroll.retro import RetroMismatch, calculate_snapshot_driven_retro
+
+
+def _snapshot(session: Session, employee_no: str, period: str, marker: str) -> PersonnelSnapshotRecord:
+    snapshot = PersonnelSnapshotRecord(
+        employee_no=employee_no,
+        effective_period=period,
+        effective_date=None,
+        organization_unit_id="ORG-1",
+        position_id="POS-1",
+        employment_type="teacher",
+        employment_status="active",
+        source_hash=sha256(marker.encode()).hexdigest(),
+        snapshot_hash=sha256(f"{employee_no}|{period}|{marker}".encode()).hexdigest(),
+        order_numbers=[],
+        components={"marker": marker},
+    )
+    session.add(snapshot)
+    session.flush()
+    return snapshot
+
+
+def _artifact(session: Session, snapshot: PersonnelSnapshotRecord, *, run_marker: str, net: str) -> PayrollArtifactRecord:
+    artifact = PayrollArtifactRecord(
+        id=uuid4(),
+        payroll_run_id=uuid4(),
+        employee_no=snapshot.employee_no,
+        period=snapshot.effective_period,
+        personnel_snapshot_id=snapshot.id,
+        personnel_snapshot_hash=snapshot.snapshot_hash,
+        rule_pack_version="test-pack",
+        rule_pack_hash="r" * 64,
+        input_hash=sha256(run_marker.encode()).hexdigest(),
+        output_hash="pending",
+        gross=Decimal(net) + Decimal("100"),
+        deductions=Decimal("100"),
+        net=Decimal(net),
+    )
+    session.add(artifact)
+    session.flush()
+    return artifact
+
+
+def _output_hash(employee_no: str, period: str, amount: str) -> str:
+    calculation = PayrollCalculator().calculate(
+        employee_no=employee_no,
+        period=period,
+        ruleset_version="test-pack",
+        lines=[PayrollLine(code="BASE", title="Base", amount=Decimal(amount), kind="earning")],
+    )
+    output = {
+        "gross": str(calculation.result.gross),
+        "deductions": str(calculation.result.deductions),
+        "net": str(calculation.result.net),
+        "fingerprint": calculation.fingerprint,
+    }
+    return sha256(json.dumps(output, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def test_replay_requires_historical_snapshot_and_hash() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        snapshot = _snapshot(session, "E-1", "1405-05", "frozen")
+        artifact = _artifact(session, snapshot, run_marker="run", net="1000")
+        artifact.output_hash = _output_hash("E-1", "1405-05", "1000")
+        session.add(
+            PayslipLineRecord(
+                artifact_id=artifact.id,
+                line_sequence=1,
+                employee_no="E-1",
+                code="BASE",
+                title="Base",
+                amount=Decimal("1000"),
+                kind="earning",
+            )
+        )
+        session.commit()
+        result = replay_artifact(session, artifact.id)
+        assert result["matches"] is True
+        assert result["personnel_snapshot_hash"] == snapshot.snapshot_hash
+
+        artifact.personnel_snapshot_hash = "x" * 64
+        with pytest.raises(ReplayMismatch, match="snapshot hash"):
+            replay_artifact(session, artifact.id)
+
+
+def test_snapshot_retro_requires_the_same_frozen_snapshot() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        snapshot = _snapshot(session, "E-2", "1405-05", "frozen")
+        old_artifact = _artifact(session, snapshot, run_marker="old", net="1000")
+        new_artifact = _artifact(session, snapshot, run_marker="new", net="1125")
+        session.commit()
+        result = calculate_snapshot_driven_retro(
+            session,
+            employee_no="E-2",
+            original_artifacts={"1405-05": old_artifact.id},
+            revised_artifacts={"1405-05": new_artifact.id},
+        )
+        assert result.snapshot_driven is True
+        assert result.net_difference == Decimal("125")
+        assert result.periods[0].original_snapshot_id == snapshot.id
+        assert result.periods[0].revised_snapshot_id == snapshot.id
+
+        with pytest.raises(RetroMismatch, match="both original and revised"):
+            calculate_snapshot_driven_retro(
+                session,
+                employee_no="E-2",
+                original_artifacts={"1405-06": old_artifact.id},
+                revised_artifacts={},
+            )


### PR DESCRIPTION
## M3.13

Implements the snapshot-driven retroactive recalculation / historical replay provenance boundary on current `main`.

### Changes
- bind historical replay to persisted `PersonnelSnapshotRecord` identity and SHA-256 hash
- fail closed on missing, mismatched, or tampered historical snapshots
- add deterministic snapshot-driven retro reconciliation over persisted original/revised payroll artifacts
- require original and revised artifacts for every period and the same immutable snapshot per period
- preserve rule-pack versions and snapshot evidence in retro/replay results
- add focused regression tests
- add dedicated M3.13 GitHub Actions gate
- update roadmap, implementation matrix, and M3.13 technical documentation

### Safety boundary
No legal rates, thresholds, or formulas are inferred or activated. This tranche does not constitute legal or production certification of historical payroll replay.