### PR TITLE
feat: M3.16 harden employee self-service payslip experience

### DIFF
--- a/.github/workflows/m3-16-self-service-hardening.yml
+++ b/.github/workflows/m3-16-self-service-hardening.yml
@@ -1,0 +1,27 @@
+name: M3.16 Self-Service Production Hardening Gate
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  m3-16-self-service-hardening:
+    name: M3.16 self-service UX, reporting and web quality gate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - run: npm run type-check
+      - run: npx vitest run --passWithNoTests
+      - run: npm run build

--- a/.github/workflows/m3-16-self-service-hardening.yml
+++ b/.github/workflows/m3-16-self-service-hardening.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: npm ci

--- a/docs/IMPLEMENTATION_MATRIX.md
+++ b/docs/IMPLEMENTATION_MATRIX.md
@@ -16,7 +16,7 @@
 | 10 | Approval / SoD | permission + privileged + distinct-actor controls implemented for personnel-order decisions; durable enterprise IAM workflow pending |
 | 11 | SINA Adapter | fail-closed typed contract; official schema/endpoint/credential and staging evidence required |
 | 12 | Accounting / Treasury / Bank | typed six-provider boundary + transactional outbox/inbox foundations; official adapters required |
-| 13 | Employee Self-Service | **M3.15 implemented authenticated self profile, approved/frozen payroll artifact listing/detail, immutable snapshot verification, personnel-order read view and artifact-bound PDF download; production UX hardening and identity-directory reconciliation pending** |
+| 13 | Employee Self-Service | **M3.15 implemented authenticated self profile, approved/frozen payroll artifact listing/detail, immutable snapshot verification, personnel-order read view and artifact-bound PDF download; M3.16 adds period filtering, detailed payslip/provenance presentation and resilient download UX; identity-directory reconciliation remains pending** |
 | 14 | Payslip Explanation | persisted payroll artifact + ordered line explanation implemented; employee self-service exposes line explanations and provenance hashes; authoritative legal source linking remains pending |
 | 15 | Rule Sandbox UI | foundation; production hardening pending |
 | 16 | Management Dashboard | authenticated employee/payroll/approval summary APIs wired to the operational dashboard; historical charts and broader operational KPIs pending |
@@ -33,7 +33,7 @@
 | 27 | Core HR Employee Profile API | implemented read APIs for employee, employment, assignment, education, experience and dependents; automated API coverage added; production master-data validation pending |
 | 28 | Core HR Effective Snapshots | implemented immutable period snapshot creation/read API with deterministic content hash; payroll/order population integration and production master-data evidence pending |
 | 29 | Employee Objection / Case Management | **M3.15 implemented persistent case creation/list/detail/status lifecycle, employee-only self access, organization-hierarchy authorization for staff handling, resolution requirements and audit events; formal enterprise grievance policy/SLA evidence pending** |
-| 30 | Employee Payslip PDF | **M3.15 implemented deterministic artifact-bound PDF download behind authenticated self-service and snapshot/hash verification; typography/localization and production document-template certification pending** |
+| 30 | Employee Payslip PDF | **M3.15 implemented deterministic artifact-bound PDF download behind authenticated self-service and snapshot/hash verification; M3.16 adds a tested user-facing detail/provenance view and resilient download workflow; typography/localization and production document-template certification pending** |
 
 ## Canonical payroll lifecycle
 
@@ -65,7 +65,7 @@ M3.14 removes hardcoded dashboard and employee-list business data from the prima
 
 ## Employee Self-Service / Case Governance
 
-M3.15 adds an authenticated employee boundary at `/api/v1/self` and `/api/v1/cases/self`. Employee identity must resolve to an existing personnel record; otherwise the request fails closed. Employee payroll views expose only artifacts attached to approved-or-later payroll lifecycle states and verify the immutable `PersonnelSnapshotRecord` hash before detail or PDF access. Objections/cases persist employee ownership, lifecycle status, priority and resolution evidence; staff case handling is restricted through the existing hierarchical personnel authorization boundary and each creation/status change/download appends an audit event. The PDF implementation is deterministic and artifact-bound but remains a document-generation foundation: template localization, typography, retention and formal document certification remain separate operational requirements.
+M3.15 adds an authenticated employee boundary at `/api/v1/self` and `/api/v1/cases/self`. Employee identity must resolve to an existing personnel record; otherwise the request fails closed. Employee payroll views expose only artifacts attached to approved-or-later payroll lifecycle states and verify the immutable `PersonnelSnapshotRecord` hash before detail or PDF access. Objections/cases persist employee ownership, lifecycle status, priority and resolution evidence; staff case handling is restricted through the existing hierarchical personnel authorization boundary and each creation/status change/download appends an audit event. M3.16 hardens the web presentation with server-backed period filtering, on-demand payslip detail, visible snapshot/provenance hashes, explicit loading/error states and resilient PDF download lifecycle. The PDF remains a document-generation foundation: template localization, typography, retention and formal document certification remain separate operational requirements.
 
 ## Release position
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,6 +26,7 @@
 - M3.13 snapshot-driven retro/replay provenance boundary with immutable historical snapshot binding and dedicated CI gate
 - M3.14 authenticated operational dashboard/employee views with explicit API loading/error/empty states
 - M3.15 authenticated employee self-service, objection/case persistence and artifact-bound payslip PDF endpoint with dedicated CI gate
+- M3.16 employee self-service UX hardening with payslip detail/provenance presentation, period filtering, resilient PDF download handling and dedicated web quality gate
 
 ## Current execution queue
 
@@ -37,7 +38,7 @@
 6. Complete tax, pension, insurance, loans and judicial-deduction ledgers with approved treatments. **M3.12 governance boundary is implemented; authoritative treatment evidence and approved population-specific rules remain pending.**
 7. Complete snapshot-driven retroactive recalculation and certified historical replay corpus. **M3.13 software provenance/reconciliation controls are implemented; authoritative historical replay corpus and certification evidence remain pending.**
 8. Remove remaining demonstration-only frontend behavior and wire operational views to authenticated APIs. **M3.14 completed for the primary dashboard/employee views.**
-9. Complete employee self-service, objection/case management and production PDF/reporting. **M3.15 foundation implemented: authenticated self-service profile/payslips/orders, artifact-bound PDF download, persistent employee cases and employee case lifecycle API. Production UX hardening, broader reporting and certification evidence remain pending.**
+9. Complete employee self-service, objection/case management and production PDF/reporting. **M3.15 foundation and M3.16 UX hardening implemented: authenticated self-service profile/payslips/orders, artifact-bound PDF download, persistent employee cases, payslip detail/provenance view, period filter and resilient download UX. Identity-directory reconciliation, broader reporting, document-template certification and enterprise grievance policy/SLA evidence remain pending.**
 10. Implement official SINA, accounting, treasury, bank, tax and insurance adapters only from authoritative contracts.
 11. Run staging tests for every adapter and at least one pilot environment where authorized.
 12. Complete end-to-end three-way reconciliation: Morva entitlement ↔ Treasury/PFM instruction ↔ Bank settlement.

--- a/web/src/__tests__/SelfService.test.tsx
+++ b/web/src/__tests__/SelfService.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';

--- a/web/src/__tests__/SelfService.test.tsx
+++ b/web/src/__tests__/SelfService.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import SelfService from '../pages/SelfService';
+import { selfService } from '../services/self-service';
+
+vi.mock('../services/self-service', () => ({
+  selfService: {
+    getProfile: vi.fn(),
+    getPayslips: vi.fn(),
+    getPayslip: vi.fn(),
+    getPayslipPdf: vi.fn(),
+    getOrders: vi.fn(),
+  },
+}));
+
+const mockedSelfService = vi.mocked(selfService);
+
+const renderPage = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SelfService />
+    </QueryClientProvider>,
+  );
+};
+
+describe('SelfService', () => {
+  it('shows payslip details only after the employee selects a payslip', async () => {
+    mockedSelfService.getProfile.mockResolvedValue({
+      data: {
+        employee_no: 'E-100',
+        first_name: 'علی',
+        last_name: 'مرندی',
+        employment_type: 'official',
+        status: 'active',
+        organization_unit_id: 'org-1',
+        position_id: 'pos-1',
+        hire_date: '2020-01-01',
+      },
+    } as never);
+    mockedSelfService.getPayslips.mockResolvedValue({
+      data: [{
+        artifact_id: 'artifact-1',
+        period: '۱۴۰۵-۰۶',
+        currency_code: 'IRR',
+        gross: '1000',
+        deductions: '100',
+        net: '900',
+        status: 'frozen',
+        personnel_snapshot_hash: 'snapshot-hash',
+        rule_pack_version: '1405.1',
+        output_hash: 'output-hash',
+      }],
+    } as never);
+    mockedSelfService.getOrders.mockResolvedValue({ data: [] } as never);
+    mockedSelfService.getPayslip.mockResolvedValue({
+      data: {
+        artifact_id: 'artifact-1',
+        employee_no: 'E-100',
+        period: '۱۴۰۵-۰۶',
+        currency_code: 'IRR',
+        gross: '1000',
+        deductions: '100',
+        net: '900',
+        status: 'frozen',
+        personnel_snapshot_id: 'snapshot-1',
+        personnel_snapshot_hash: 'snapshot-hash',
+        rule_pack_version: '1405.1',
+        input_hash: 'input-hash',
+        output_hash: 'output-hash',
+        lines: [{
+          sequence: 1,
+          code: 'BASE',
+          title: 'حقوق پایه',
+          amount: '1000',
+          kind: 'earning',
+          taxable: true,
+          pensionable: true,
+          insurable: true,
+          explanation: 'مبلغ پایه',
+        }],
+      },
+    } as never);
+
+    renderPage();
+    await screen.findByText('۱۴۰۵-۰۶');
+    expect(screen.queryByText('حقوق پایه')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'جزئیات' }));
+    expect(await screen.findByText('حقوق پایه')).toBeInTheDocument();
+    expect(screen.getByText('snapshot-hash')).toBeInTheDocument();
+    expect(mockedSelfService.getPayslip).toHaveBeenCalledWith('artifact-1');
+  });
+
+  it('reports a PDF download failure without leaving the button busy', async () => {
+    mockedSelfService.getProfile.mockResolvedValue({ data: { employee_no: 'E-100', first_name: 'علی', last_name: 'مرندی', employment_type: 'official', status: 'active', organization_unit_id: 'org-1', position_id: 'pos-1' } } as never);
+    mockedSelfService.getPayslips.mockResolvedValue({ data: [{ artifact_id: 'artifact-2', period: '۱۴۰۵-۰۵', currency_code: 'IRR', gross: '100', deductions: '10', net: '90', status: 'approved', personnel_snapshot_hash: 'hash', rule_pack_version: '1405.1', output_hash: 'out' }] } as never);
+    mockedSelfService.getOrders.mockResolvedValue({ data: [] } as never);
+    mockedSelfService.getPayslipPdf.mockRejectedValue(new Error('download failed'));
+
+    renderPage();
+    await screen.findByText('۱۴۰۵-۰۵');
+    const button = screen.getByRole('button', { name: 'PDF' });
+    fireEvent.click(button);
+    expect(await screen.findByText(/دریافت فایل PDF ناموفق بود/)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'PDF' })).not.toBeDisabled());
+  });
+});

--- a/web/src/components/charts/PayrollChart.tsx
+++ b/web/src/components/charts/PayrollChart.tsx
@@ -1,16 +1,18 @@
 import React from "react";
-import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
 
-const data = [
-  { month: "اردیبهشت", salary: 4500000, deductions: 800000, net: 3700000 },
-  { month: "خرداد", salary: 4500000, deductions: 800000, net: 3700000 },
-  { month: "تیر", salary: 4800000, deductions: 900000, net: 3900000 },
-  { month: "مرداد", salary: 4800000, deductions: 900000, net: 3900000 },
-  { month: "شهریور", salary: 5100000, deductions: 950000, net: 4150000 },
-  { month: "مهر", salary: 5100000, deductions: 950000, net: 4150000 },
-];
+export interface PayrollChartRecord {
+  month: string;
+  processed: number;
+  pending: number;
+  rejected: number;
+}
 
-function PayrollChart() {
+interface PayrollChartProps {
+  data: PayrollChartRecord[];
+}
+
+function PayrollChart({ data }: PayrollChartProps) {
   return (
     <ResponsiveContainer width="100%" height={300}>
       <BarChart data={data} margin={{ top: 20, right: 30, left: 0, bottom: 60 }}>
@@ -26,9 +28,9 @@ function PayrollChart() {
           cursor={{ fill: "rgba(122, 158, 198, 0.1)" }}
         />
         <Legend wrapperStyle={{ paddingTop: "20px" }} />
-        <Bar dataKey="salary" fill="#5a7fb0" name="حقوق‌ها" radius={[8, 8, 0, 0]} />
-        <Bar dataKey="deductions" fill="#e67e22" name="کسورات" radius={[8, 8, 0, 0]} />
-        <Bar dataKey="net" fill="#27ae60" name="خالص" radius={[8, 8, 0, 0]} />
+        <Bar dataKey="processed" fill="#5a7fb0" name="تکمیل‌شده" radius={[8, 8, 0, 0]} />
+        <Bar dataKey="pending" fill="#e67e22" name="در انتظار" radius={[8, 8, 0, 0]} />
+        <Bar dataKey="rejected" fill="#27ae60" name="رد‌شده" radius={[8, 8, 0, 0]} />
       </BarChart>
     </ResponsiveContainer>
   );

--- a/web/src/hooks/useApi.ts
+++ b/web/src/hooks/useApi.ts
@@ -3,35 +3,8 @@
  * Combines React Query hooks with error handling and loading states
  */
 
-import { useQuery, useMutation } from '@tanstack/react-query';
-import {
-  useLogin,
-  useLogout,
-  useAuthMe,
-  useEmployees,
-  useEmployee,
-  useCreateEmployee,
-  useUpdateEmployee,
-  useDeleteEmployee,
-  useEmployeeStats,
-  usePayrolls,
-  usePayroll,
-  useCreatePayroll,
-  useProcessPayroll,
-  useApprovePayroll,
-  usePayrollStats,
-  useApprovals,
-  usePendingApprovals,
-  useApproveRequest,
-  useRejectRequest,
-  useApprovalsStats,
-  useReports,
-  useReport,
-  useGenerateReport,
-  useReportsStats,
-} from '../services/queries';
-
-// ============= Dashboard Hooks =============
+import { useLogin, useLogout, useAuthMe, useEmployees, useEmployee, useCreateEmployee, useUpdateEmployee, useDeleteEmployee, useEmployeeStats, usePayrolls, usePayroll, useCreatePayroll, useProcessPayroll, useApprovePayroll, usePayrollStats, useApprovals, usePendingApprovals, useApproveRequest, useRejectRequest, useApprovalsStats, useReports, useReport, useGenerateReport, useReportsStats } from '../services/queries';
+import type { UseQueryOptions } from '@tanstack/react-query';
 
 export function useDashboardData() {
   const employeeStats = useEmployeeStats();
@@ -43,17 +16,8 @@ export function useDashboardData() {
     enabled: approvalsStats.isSuccess,
   });
 
-  const isLoading =
-    employeeStats.isLoading ||
-    payrollStats.isLoading ||
-    approvalsStats.isLoading ||
-    reportsStats.isLoading;
-
-  const isError =
-    employeeStats.isError ||
-    payrollStats.isError ||
-    approvalsStats.isError ||
-    reportsStats.isError;
+  const isLoading = employeeStats.isLoading || payrollStats.isLoading || approvalsStats.isLoading || reportsStats.isLoading;
+  const isError = employeeStats.isError || payrollStats.isError || approvalsStats.isError || reportsStats.isError;
 
   return {
     employeeStats: employeeStats.data?.data,
@@ -63,165 +27,67 @@ export function useDashboardData() {
     pendingApprovals: pendingApprovals.data?.data,
     isLoading,
     isError,
-    error: isError
-      ? employeeStats.error ||
-        payrollStats.error ||
-        approvalsStats.error ||
-        reportsStats.error
-      : null,
+    error: isError ? employeeStats.error || payrollStats.error || approvalsStats.error || reportsStats.error : null,
   };
 }
-
-// ============= Employees Page Hooks =============
 
 export function useEmployeesPageData(filters: any = {}) {
   const employees = useEmployees(filters);
   const stats = useEmployeeStats();
-
-  return {
-    employees: employees.data?.data?.items || [],
-    total: employees.data?.data?.total || 0,
-    stats: stats.data?.data,
-    isLoading: employees.isLoading || stats.isLoading,
-    isError: employees.isError || stats.isError,
-    error: employees.error || stats.error,
-    refetch: () => {
-      employees.refetch();
-      stats.refetch();
-    },
-  };
+  return { employees: employees.data?.data?.items || [], total: employees.data?.data?.total || 0, stats: stats.data?.data, isLoading: employees.isLoading || stats.isLoading, isError: employees.isError || stats.isError, error: employees.error || stats.error, refetch: () => { employees.refetch(); stats.refetch(); } };
 }
 
 export function useEmployeeForm() {
   const create = useCreateEmployee();
   const update = useUpdateEmployee;
   const delete_ = useDeleteEmployee;
-
-  return {
-    create,
-    update,
-    delete: delete_,
-  };
+  return { create, update, delete: delete_ };
 }
-
-// ============= Payroll Page Hooks =============
 
 export function usePayrollPageData(filters: any = {}) {
   const payrolls = usePayrolls(filters);
   const stats = usePayrollStats();
-
-  return {
-    payrolls: payrolls.data?.data?.items || [],
-    total: payrolls.data?.data?.total || 0,
-    stats: stats.data?.data,
-    isLoading: payrolls.isLoading || stats.isLoading,
-    isError: payrolls.isError || stats.isError,
-    error: payrolls.error || stats.error,
-  };
+  return { payrolls: payrolls.data?.data?.items || [], total: payrolls.data?.data?.total || 0, stats: stats.data?.data, isLoading: payrolls.isLoading || stats.isLoading, isError: payrolls.isError || stats.isError, error: payrolls.error || stats.error };
 }
 
 export function usePayrollActions() {
   const create = useCreatePayroll();
   const process = useProcessPayroll();
   const approve = useApprovePayroll();
-
-  return {
-    create,
-    process,
-    approve,
-  };
+  return { create, process, approve };
 }
-
-// ============= Approvals Page Hooks =============
 
 export function useApprovalsPageData(filters: any = {}) {
   const approvals = useApprovals(filters);
   const pending = usePendingApprovals(filters);
   const stats = useApprovalsStats();
-
-  return {
-    allApprovals: approvals.data?.data?.items || [],
-    pendingApprovals: pending.data?.data?.items || [],
-    total: approvals.data?.data?.total || 0,
-    stats: stats.data?.data,
-    isLoading: approvals.isLoading || pending.isLoading || stats.isLoading,
-    isError: approvals.isError || pending.isError || stats.isError,
-    error: approvals.error || pending.error || stats.error,
-  };
+  return { allApprovals: approvals.data?.data?.items || [], pendingApprovals: pending.data?.data?.items || [], total: approvals.data?.data?.total || 0, stats: stats.data?.data, isLoading: approvals.isLoading || pending.isLoading || stats.isLoading, isError: approvals.isError || pending.isError || stats.isError, error: approvals.error || pending.error || stats.error };
 }
 
 export function useApprovalActions() {
   const approve = useApproveRequest();
   const reject = useRejectRequest();
-
-  return {
-    approve,
-    reject,
-  };
+  return { approve, reject };
 }
-
-// ============= Reports Page Hooks =============
 
 export function useReportsPageData(filters: any = {}) {
   const reports = useReports(filters);
   const stats = useReportsStats();
-
-  return {
-    reports: reports.data?.data?.items || [],
-    total: reports.data?.data?.total || 0,
-    stats: stats.data?.data,
-    isLoading: reports.isLoading || stats.isLoading,
-    isError: reports.isError || stats.isError,
-    error: reports.error || stats.error,
-  };
+  return { reports: reports.data?.data?.items || [], total: reports.data?.data?.total || 0, stats: stats.data?.data, isLoading: reports.isLoading || stats.isLoading, isError: reports.isError || stats.isError, error: reports.error || stats.error };
 }
 
 export function useReportGeneration() {
   const generate = useGenerateReport();
-
-  return {
-    generate,
-  };
+  return { generate };
 }
-
-// ============= Auth Hooks =============
 
 export function useAuthActions() {
   const login = useLogin();
   const logout = useLogout();
   const me = useAuthMe();
-
-  return {
-    login,
-    logout,
-    me,
-  };
+  return { login, logout, me };
 }
 
-// Re-export individual hooks for advanced usage
-export {
-  useLogin,
-  useLogout,
-  useAuthMe,
-  useEmployees,
-  useEmployee,
-  useCreateEmployee,
-  useUpdateEmployee,
-  useDeleteEmployee,
-  useEmployeeStats,
-  usePayrolls,
-  usePayroll,
-  useCreatePayroll,
-  useProcessPayroll,
-  useApprovePayroll,
-  usePayrollStats,
-  useApprovals,
-  usePendingApprovals,
-  useApproveRequest,
-  useRejectRequest,
-  useApprovalsStats,
-  useReports,
-  useReport,
-  useGenerateReport,
-  useReportsStats,
-};
+export type PendingApprovalQueryOptions = Omit<UseQueryOptions<any>, 'queryKey' | 'queryFn'>;
+
+export { useLogin, useLogout, useAuthMe, useEmployees, useEmployee, useCreateEmployee, useUpdateEmployee, useDeleteEmployee, useEmployeeStats, usePayrolls, usePayroll, useCreatePayroll, useProcessPayroll, useApprovePayroll, usePayrollStats, useApprovals, usePendingApprovals, useApproveRequest, useRejectRequest, useApprovalsStats, useReports, useReport, useGenerateReport, useReportsStats };

--- a/web/src/hooks/useApi.ts
+++ b/web/src/hooks/useApi.ts
@@ -29,7 +29,7 @@ import {
   useReport,
   useGenerateReport,
   useReportsStats,
-} from './services/queries';
+} from '../services/queries';
 
 // ============= Dashboard Hooks =============
 
@@ -38,11 +38,11 @@ export function useDashboardData() {
   const payrollStats = usePayrollStats();
   const approvalsStats = useApprovalsStats();
   const reportsStats = useReportsStats();
-  
+
   const pendingApprovals = usePendingApprovals(undefined, {
     enabled: approvalsStats.isSuccess,
   });
-  
+
   const isLoading =
     employeeStats.isLoading ||
     payrollStats.isLoading ||

--- a/web/src/pages/Approvals.tsx
+++ b/web/src/pages/Approvals.tsx
@@ -15,110 +15,58 @@ const Approvals: React.FC = () => {
   const [filter, setFilter] = useState<"all" | "pending" | "approved" | "rejected">("all");
 
   const requests: ApprovalRequest[] = [
-    {
-      id: "APR001",
-      type: "درخواست مرخصی",
-      employee: "علی محمدی",
-      status: "pending",
-      date: "۱۴۰۵-۰۶-۱۵",
-    },
-    {
-      id: "APR002",
-      type: "درخواست پاداش",
-      employee: "فاطمه احمدی",
-      amount: "۵،۰۰۰،۰۰۰",
-      status: "approved",
-      date: "۱۴۰۵-۰۶-۱۴",
-    },
-    {
-      id: "APR003",
-      type: "افزایش حقوق",
-      employee: "حسن حسینی",
-      status: "pending",
-      date: "۱۴۰۵-۰۶-۱۳",
-    },
-    {
-      id: "APR004",
-      type: "تغییر پوسیشن",
-      employee: "نازنین رضایی",
-      status: "rejected",
-      date: "۱۴۰۵-۰۶-۱۲",
-    },
-    {
-      id: "APR005",
-      type: "درخواست مرخصی",
-      employee: "محمد علیپور",
-      status: "approved",
-      date: "۱۴۰۵-۰۶-۱۱",
-    },
+    { id: "APR001", type: "درخواست مرخصی", employee: "علی محمدی", status: "pending", date: "۱۴۰۵-۰۶-۱۵" },
+    { id: "APR002", type: "درخواست پاداش", employee: "فاطمه احمدی", amount: "۵،۰۰۰،۰۰۰", status: "approved", date: "۱۴۰۵-۰۶-۱۴" },
+    { id: "APR003", type: "افزایش حقوق", employee: "حسن حسینی", status: "pending", date: "۱۴۰۵-۰۶-۱۳" },
+    { id: "APR004", type: "تغییر پوسیشن", employee: "نازنین رضایی", status: "rejected", date: "۱۴۰۵-۰۶-۱۲" },
+    { id: "APR005", type: "درخواست مرخصی", employee: "محمد علیپور", status: "approved", date: "۱۴۰۵-۰۶-۱۱" },
   ];
 
-  const stats = {
-    pending: 8,
-    approved: 15,
-    rejected: 2,
-    total: 25,
-  };
+  const stats = { pending: 8, approved: 15, rejected: 2, total: 25 };
 
   const filteredRequests =
-    filter === "all"
-      ? requests
-      : requests.filter((req) => req.status === filter);
+    filter === "all" ? requests : requests.filter((req) => req.status === filter);
 
   return (
     <div className="min-h-screen bg-gray-50 p-4 md:p-8">
       <div className="max-w-7xl mx-auto">
-        {/* Header */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900">تأیید و بررسی</h1>
-          <p className="text-gray-600 mt-2">
-            مدیریت درخواست‌های تأیید و بررسی مستندات
-          </p>
+          <p className="text-gray-600 mt-2">مدیریت درخواست‌های تأیید و بررسی مستندات</p>
         </div>
 
-        {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-          <StatCard
-            title="کل درخواست‌ها"
-            value={stats.total.toString()}
-            icon={Inbox}
-            trend="↑ ۳"
-            color="blue"
-          />
-          <StatCard
-            title="در انتظار تأیید"
-            value={stats.pending.toString()}
-            icon={Clock}
-            trend={`${((stats.pending / stats.total) * 100).toFixed(0)}%`}
-            color="orange"
-          />
-          <StatCard
-            title="تأیید‌شده"
-            value={stats.approved.toString()}
-            icon={CheckCircle}
-            trend={`${((stats.approved / stats.total) * 100).toFixed(0)}%`}
-            color="green"
-          />
-          <StatCard
-            title="رد‌شده"
-            value={stats.rejected.toString()}
-            icon={XCircle}
-            trend={`${((stats.rejected / stats.total) * 100).toFixed(0)}%`}
-            color="red"
-          />
+          <StatCard title="کل درخواست‌ها" value={stats.total.toString()} icon={Inbox} trend="↑ ۳" color="blue" />
+          <StatCard title="در انتظار تأیید" value={stats.pending.toString()} icon={Clock} trend={`${((stats.pending / stats.total) * 100).toFixed(0)}%`} color="orange" />
+          <StatCard title="تأیید‌شده" value={stats.approved.toString()} icon={CheckCircle} trend={`${((stats.approved / stats.total) * 100).toFixed(0)}%`} color="green" />
+          <StatCard title="رد‌شده" value={stats.rejected.toString()} icon={XCircle} trend={`${((stats.rejected / stats.total) * 100).toFixed(0)}%`} color="red" />
         </div>
 
-        {/* Filter Buttons */}
         <div className="flex flex-wrap gap-2 mb-8">
-          {["all", "pending", "approved", "rejected"] as const}.map
+          {["all", "pending", "approved", "rejected"] as const}.map((status) => (
+            <button
+              key={status}
+              onClick={() => setFilter(status)}
+              className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                filter === status
+                  ? status === "pending"
+                    ? "bg-orange-100 text-orange-700"
+                    : status === "approved"
+                      ? "bg-green-100 text-green-700"
+                      : status === "rejected"
+                        ? "bg-red-100 text-red-700"
+                        : "bg-blue-100 text-blue-700"
+                  : "bg-white text-gray-700 border border-gray-200"
+              }`}
+            >
+              {status === "all" ? "همه" : status === "pending" ? "در انتظار" : status === "approved" ? "تأیید‌شده" : "رد‌شده"}
+            </button>
+          ))}
         </div>
 
-        {/* Requests Table */}
         <div className="bg-white rounded-lg shadow overflow-hidden">
           <div className="px-6 py-4 border-b border-gray-200">
-            <h2 className="text-xl font-bold text-gray-900">
-              درخواست‌های تأیید
-            </h2>
+            <h2 className="text-xl font-bold text-gray-900">درخواست‌های تأیید</h2>
           </div>
           <div className="overflow-x-auto">
             <table className="w-full">
@@ -140,15 +88,7 @@ const Approvals: React.FC = () => {
                     <td className="px-6 py-4 text-right text-sm text-gray-600">{req.amount || "—"}</td>
                     <td className="px-6 py-4 text-right text-sm text-gray-600">{req.date}</td>
                     <td className="px-6 py-4 text-right text-sm">
-                      <span
-                        className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium ${
-                          req.status === "pending"
-                            ? "bg-orange-100 text-orange-800"
-                            : req.status === "approved"
-                              ? "bg-green-100 text-green-800"
-                              : "bg-red-100 text-red-800"
-                        }`}
-                      >
+                      <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium ${req.status === "pending" ? "bg-orange-100 text-orange-800" : req.status === "approved" ? "bg-green-100 text-green-800" : "bg-red-100 text-red-800"}`}>
                         {req.status === "pending" ? "در انتظار" : req.status === "approved" ? "تأیید‌شده" : "رد‌شده"}
                       </span>
                     </td>

--- a/web/src/pages/Approvals.tsx
+++ b/web/src/pages/Approvals.tsx
@@ -43,7 +43,7 @@ const Approvals: React.FC = () => {
         </div>
 
         <div className="flex flex-wrap gap-2 mb-8">
-          {["all", "pending", "approved", "rejected"] as const}.map((status) => (
+          {(["all", "pending", "approved", "rejected"] as const).map((status) => (
             <button
               key={status}
               onClick={() => setFilter(status)}

--- a/web/src/pages/Approvals.tsx
+++ b/web/src/pages/Approvals.tsx
@@ -81,28 +81,28 @@ const Approvals: React.FC = () => {
           <StatCard
             title="کل درخواست‌ها"
             value={stats.total.toString()}
-            icon={<Inbox className="w-8 h-8" />}
+            icon={Inbox}
             trend="↑ ۳"
             color="blue"
           />
           <StatCard
             title="در انتظار تأیید"
             value={stats.pending.toString()}
-            icon={<Clock className="w-8 h-8" />}
+            icon={Clock}
             trend={`${((stats.pending / stats.total) * 100).toFixed(0)}%`}
             color="orange"
           />
           <StatCard
             title="تأیید‌شده"
             value={stats.approved.toString()}
-            icon={<CheckCircle className="w-8 h-8" />}
+            icon={CheckCircle}
             trend={`${((stats.approved / stats.total) * 100).toFixed(0)}%`}
             color="green"
           />
           <StatCard
             title="رد‌شده"
             value={stats.rejected.toString()}
-            icon={<XCircle className="w-8 h-8" />}
+            icon={XCircle}
             trend={`${((stats.rejected / stats.total) * 100).toFixed(0)}%`}
             color="red"
           />
@@ -110,33 +110,7 @@ const Approvals: React.FC = () => {
 
         {/* Filter Buttons */}
         <div className="flex flex-wrap gap-2 mb-8">
-          {(["all", "pending", "approved", "rejected"] as const).map(
-            (status) => (
-              <button
-                key={status}
-                onClick={() => setFilter(status)}
-                className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                  filter === status
-                    ? status === "pending"
-                      ? "bg-orange-100 text-orange-700"
-                      : status === "approved"
-                        ? "bg-green-100 text-green-700"
-                        : status === "rejected"
-                          ? "bg-red-100 text-red-700"
-                          : "bg-blue-100 text-blue-700"
-                    : "bg-white text-gray-700 border border-gray-200"
-                }`}
-              >
-                {status === "all"
-                  ? "همه"
-                  : status === "pending"
-                    ? "در انتظار"
-                    : status === "approved"
-                      ? "تأیید‌شده"
-                      : "رد‌شده"}
-              </button>
-            )
-          )}
+          {["all", "pending", "approved", "rejected"] as const}.map
         </div>
 
         {/* Requests Table */}
@@ -150,41 +124,21 @@ const Approvals: React.FC = () => {
             <table className="w-full">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">
-                    نوع درخواست
-                  </th>
-                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">
-                    نام کارمند
-                  </th>
-                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">
-                    مبلغ
-                  </th>
-                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">
-                    تاریخ
-                  </th>
-                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">
-                    وضعیت
-                  </th>
-                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">
-                    عملیات
-                  </th>
+                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">نوع درخواست</th>
+                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">نام کارمند</th>
+                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">مبلغ</th>
+                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">تاریخ</th>
+                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">وضعیت</th>
+                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">عملیات</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
                 {filteredRequests.map((req) => (
                   <tr key={req.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 text-right text-sm text-gray-900">
-                      {req.type}
-                    </td>
-                    <td className="px-6 py-4 text-right text-sm text-gray-600">
-                      {req.employee}
-                    </td>
-                    <td className="px-6 py-4 text-right text-sm text-gray-600">
-                      {req.amount || "—"}
-                    </td>
-                    <td className="px-6 py-4 text-right text-sm text-gray-600">
-                      {req.date}
-                    </td>
+                    <td className="px-6 py-4 text-right text-sm text-gray-900">{req.type}</td>
+                    <td className="px-6 py-4 text-right text-sm text-gray-600">{req.employee}</td>
+                    <td className="px-6 py-4 text-right text-sm text-gray-600">{req.amount || "—"}</td>
+                    <td className="px-6 py-4 text-right text-sm text-gray-600">{req.date}</td>
                     <td className="px-6 py-4 text-right text-sm">
                       <span
                         className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium ${
@@ -195,25 +149,16 @@ const Approvals: React.FC = () => {
                               : "bg-red-100 text-red-800"
                         }`}
                       >
-                        {req.status === "pending"
-                          ? "در انتظار"
-                          : req.status === "approved"
-                            ? "تأیید‌شده"
-                            : "رد‌شده"}
+                        {req.status === "pending" ? "در انتظار" : req.status === "approved" ? "تأیید‌شده" : "رد‌شده"}
                       </span>
                     </td>
                     <td className="px-6 py-4 text-right text-sm">
-                      {req.status === "pending" && (
+                      {req.status === "pending" ? (
                         <div className="flex gap-2">
-                          <button className="text-green-600 hover:text-green-900 font-medium">
-                            تأیید
-                          </button>
-                          <button className="text-red-600 hover:text-red-900 font-medium">
-                            رد
-                          </button>
+                          <button className="text-green-600 hover:text-green-900 font-medium">تأیید</button>
+                          <button className="text-red-600 hover:text-red-900 font-medium">رد</button>
                         </div>
-                      )}
-                      {req.status !== "pending" && (
+                      ) : (
                         <span className="text-gray-500">—</span>
                       )}
                     </td>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -40,7 +40,7 @@ function Dashboard() {
   const employeeData = employeeStats.data?.success ? employeeStats.data.data : undefined;
   const payrollData = payrollStats.data?.success ? payrollStats.data.data : undefined;
   const approvalsData = approvalsStats.data?.success ? approvalsStats.data.data : undefined;
-  const payrollItems = payrolls.data?.success ? payrolls.data.data?.items ?? [] : [];
+  const payrollItems = payrolls.data?.success ? (payrolls.data.data?.items ?? []) : [];
 
   return (
     <div className="p-6 space-y-6" dir="rtl">
@@ -50,46 +50,18 @@ function Dashboard() {
       </div>
 
       {isLoading && (
-        <div className="rounded-xl border border-morva-200 bg-white p-4 text-sm text-morva-700">
-          در حال دریافت اطلاعات عملیاتی…
-        </div>
+        <div className="rounded-xl border border-morva-200 bg-white p-4 text-sm text-morva-700">در حال دریافت اطلاعات عملیاتی…</div>
       )}
 
       {firstError && (
-        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-800" role="alert">
-          {getErrorMessage(firstError)}
-        </div>
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-800" role="alert">{getErrorMessage(firstError)}</div>
       )}
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <StatCard
-          title="کل کارکنان"
-          value={employeeData ? formatNumber(employeeData.totalEmployees) : "—"}
-          icon={Users}
-          trend={employeeData ? `${formatNumber(employeeData.activeEmployees)} فعال` : "داده موجود نیست"}
-          color="blue"
-        />
-        <StatCard
-          title="کل حقوق و دستمزد"
-          value={payrollData ? formatNumber(payrollData.totalAmount) : "—"}
-          icon={TrendingUp}
-          trend={payrollData ? `${formatNumber(payrollData.totalPayrolls)} دوره` : "داده موجود نیست"}
-          color="green"
-        />
-        <StatCard
-          title="تأییدهای معلق"
-          value={approvalsData ? formatNumber(approvalsData.pendingCount) : "—"}
-          icon={AlertCircle}
-          trend={approvalsData ? `${formatNumber(approvalsData.approvedCount)} تأییدشده` : "داده موجود نیست"}
-          color="orange"
-        />
-        <StatCard
-          title="پرداخت‌شده"
-          value={payrollData ? formatNumber(payrollData.paidAmount) : "—"}
-          icon={CheckCircle2}
-          trend={payrollData ? `${formatNumber(payrollData.averagePerPayroll)} میانگین دوره` : "داده موجود نیست"}
-          color="emerald"
-        />
+        <StatCard title="کل کارکنان" value={employeeData ? formatNumber(employeeData.totalEmployees) : "—"} icon={Users} trend={employeeData ? `${formatNumber(employeeData.activeEmployees)} فعال` : "داده موجود نیست"} color="blue" />
+        <StatCard title="کل حقوق و دستمزد" value={payrollData ? formatNumber(payrollData.totalAmount) : "—"} icon={TrendingUp} trend={payrollData ? `${formatNumber(payrollData.totalPayrolls)} دوره` : "داده موجود نیست"} color="green" />
+        <StatCard title="تأییدهای معلق" value={approvalsData ? formatNumber(approvalsData.pendingCount) : "—"} icon={AlertCircle} trend={approvalsData ? `${formatNumber(approvalsData.approvedCount)} تأییدشده` : "داده موجود نیست"} color="orange" />
+        <StatCard title="پرداخت‌شده" value={payrollData ? formatNumber(payrollData.paidAmount) : "—"} icon={CheckCircle2} trend={payrollData ? `${formatNumber(payrollData.averagePerPayroll)} میانگین دوره` : "داده موجود نیست"} color="emerald" />
       </div>
 
       <div className="bg-white rounded-xl border border-morva-200 p-6 shadow-sm">
@@ -101,9 +73,7 @@ function Dashboard() {
         </div>
 
         {!isLoading && payrollItems.length === 0 && !firstError && (
-          <div className="rounded-lg bg-morva-50 p-4 text-sm text-morva-700">
-            هیچ دوره حقوقی برای نمایش وجود ندارد.
-          </div>
+          <div className="rounded-lg bg-morva-50 p-4 text-sm text-morva-700">هیچ دوره حقوقی برای نمایش وجود ندارد.</div>
         )}
 
         {payrollItems.length > 0 && (
@@ -119,7 +89,7 @@ function Dashboard() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-morva-100">
-                {payrollItems.map((item) => (
+                {payrollItems.map((item: Payroll) => (
                   <tr key={item.id}>
                     <td className="px-3 py-3 font-medium text-morva-900">{item.period}</td>
                     <td className="px-3 py-3 text-morva-700">{formatNumber(item.employeeCount)}</td>

--- a/web/src/pages/Employees.tsx
+++ b/web/src/pages/Employees.tsx
@@ -50,21 +50,21 @@ const Employees: React.FC = () => {
           <StatCard
             title="کل کارکنان"
             value={stats ? new Intl.NumberFormat("fa-IR").format(stats.totalEmployees) : "—"}
-            icon={<Users className="w-8 h-8" />}
+            icon={Users}
             trend={stats ? `${new Intl.NumberFormat("fa-IR").format(stats.activeEmployees)} فعال` : "داده موجود نیست"}
             color="blue"
           />
           <StatCard
             title="کارکنان غیرفعال"
             value={stats ? new Intl.NumberFormat("fa-IR").format(stats.inactiveEmployees) : "—"}
-            icon={<AlertCircle className="w-8 h-8" />}
+            icon={AlertCircle}
             trend={stats ? `${new Intl.NumberFormat("fa-IR").format(stats.onLeaveEmployees)} در مرخصی` : "داده موجود نیست"}
             color="orange"
           />
           <StatCard
             title="جمع حقوق ماهانه"
             value={stats ? new Intl.NumberFormat("fa-IR").format(stats.totalPayroll) : "—"}
-            icon={<Users className="w-8 h-8" />}
+            icon={Users}
             trend={stats ? `میانگین ${new Intl.NumberFormat("fa-IR").format(stats.averageSalary)}` : "داده موجود نیست"}
             color="green"
           />
@@ -91,7 +91,7 @@ const Employees: React.FC = () => {
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-200">
-                  {employees.map((employee) => (
+                  {employees.map((employee: Employee) => (
                     <tr key={employee.id} className="hover:bg-gray-50">
                       <td className="px-6 py-4 text-right text-sm text-gray-900">{employee.name}</td>
                       <td className="px-6 py-4 text-right text-sm text-gray-600">{employee.department}</td>

--- a/web/src/pages/Payroll.tsx
+++ b/web/src/pages/Payroll.tsx
@@ -30,66 +30,33 @@ const Payroll: React.FC = () => {
   return (
     <div className="min-h-screen bg-gray-50 p-4 md:p-8">
       <div className="max-w-7xl mx-auto">
-        {/* Header */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900">مدیریت حقوق</h1>
           <p className="text-gray-600 mt-2">نظارت و پردازش حقوق کارکنان</p>
         </div>
 
-        {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-          <StatCard
-            title="کل پرداخت‌ها"
-            value={stats.totalProcessed.toString()}
-            icon={<DollarSign className="w-8 h-8" />}
-            trend="▲ ۳.۲%"
-            color="green"
-          />
-          <StatCard
-            title="میانگین حقوق"
-            value={`${(stats.avgAmount / 1000000).toFixed(1)}M`}
-            icon={<TrendingUp className="w-8 h-8" />}
-            trend="▲ ۲.۵%"
-            color="blue"
-          />
-          <StatCard
-            title="در انتظار پرداخت"
-            value={`${(stats.pendingPayment / 1000000000).toFixed(2)}B`}
-            icon={<AlertCircle className="w-8 h-8" />}
-            trend="▼ ۱.۸%"
-            color="orange"
-          />
-          <StatCard
-            title="رشد ماهیانه"
-            value={`${stats.monthlyGrowth.toFixed(1)}%`}
-            icon={<TrendingUp className="w-8 h-8" />}
-            trend="▲ ۰.۵%"
-            color="indigo"
-          />
+          <StatCard title="کل پرداخت‌ها" value={stats.totalProcessed.toString()} icon={DollarSign} trend="▲ ۳.۲%" color="green" />
+          <StatCard title="میانگین حقوق" value={`${(stats.avgAmount / 1000000).toFixed(1)}M`} icon={TrendingUp} trend="▲ ۲.۵%" color="blue" />
+          <StatCard title="در انتظار پرداخت" value={`${(stats.pendingPayment / 1000000000).toFixed(2)}B`} icon={AlertCircle} trend="▼ ۱.۸%" color="orange" />
+          <StatCard title="رشد ماهیانه" value={`${stats.monthlyGrowth.toFixed(1)}%`} icon={TrendingUp} trend="▲ ۰.۵%" color="blue" />
         </div>
 
-        {/* Charts */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
           <div className="bg-white rounded-lg shadow p-6">
-            <h2 className="text-xl font-bold text-gray-900 mb-4">
-              روند پرداخت ماهیانه
-            </h2>
+            <h2 className="text-xl font-bold text-gray-900 mb-4">روند پرداخت ماهیانه</h2>
             <PayrollChart data={payrollData} />
           </div>
 
           <div className="bg-white rounded-lg shadow p-6">
-            <h2 className="text-xl font-bold text-gray-900 mb-4">
-              خلاصه وضعیت
-            </h2>
+            <h2 className="text-xl font-bold text-gray-900 mb-4">خلاصه وضعیت</h2>
             <div className="space-y-4">
               <div className="flex items-center justify-between p-4 bg-green-50 rounded-lg">
                 <span className="font-semibold text-green-900">تکمیل‌شده</span>
                 <span className="text-2xl font-bold text-green-600">۲۳۴</span>
               </div>
               <div className="flex items-center justify-between p-4 bg-orange-50 rounded-lg">
-                <span className="font-semibold text-orange-900">
-                  در انتظار
-                </span>
+                <span className="font-semibold text-orange-900">در انتظار</span>
                 <span className="text-2xl font-bold text-orange-600">۲۵</span>
               </div>
               <div className="flex items-center justify-between p-4 bg-red-50 rounded-lg">
@@ -100,53 +67,30 @@ const Payroll: React.FC = () => {
           </div>
         </div>
 
-        {/* Recent Payroll Cycles */}
         <div className="bg-white rounded-lg shadow overflow-hidden">
           <div className="px-6 py-4 border-b border-gray-200">
-            <h2 className="text-xl font-bold text-gray-900">
-              دوره‌های حقوق اخیر
-            </h2>
+            <h2 className="text-xl font-bold text-gray-900">دوره‌های حقوق اخیر</h2>
           </div>
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">
-                    ماه
-                  </th>
-                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">
-                    تکمیل‌شده
-                  </th>
-                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">
-                    در انتظار
-                  </th>
-                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">
-                    رد‌شده
-                  </th>
-                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">
-                    وضعیت
-                  </th>
+                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">ماه</th>
+                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">تکمیل‌شده</th>
+                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">در انتظار</th>
+                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">رد‌شده</th>
+                  <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">وضعیت</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
-                {payrollData.map((record, idx) => (
-                  <tr key={idx} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 text-right text-sm font-medium text-gray-900">
-                      {record.month}
-                    </td>
-                    <td className="px-6 py-4 text-right text-sm text-gray-600">
-                      {record.processed}
-                    </td>
-                    <td className="px-6 py-4 text-right text-sm text-gray-600">
-                      {record.pending}
-                    </td>
-                    <td className="px-6 py-4 text-right text-sm text-gray-600">
-                      {record.rejected}
-                    </td>
+                {payrollData.map((record) => (
+                  <tr key={record.month} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 text-right text-sm font-medium text-gray-900">{record.month}</td>
+                    <td className="px-6 py-4 text-right text-sm text-gray-600">{record.processed}</td>
+                    <td className="px-6 py-4 text-right text-sm text-gray-600">{record.pending}</td>
+                    <td className="px-6 py-4 text-right text-sm text-gray-600">{record.rejected}</td>
                     <td className="px-6 py-4 text-right text-sm">
-                      <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                        تکمیل
-                      </span>
+                      <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">تکمیل</span>
                     </td>
                   </tr>
                 ))}

--- a/web/src/pages/Reports.tsx
+++ b/web/src/pages/Reports.tsx
@@ -13,34 +13,10 @@ interface ReportData {
 
 const Reports: React.FC = () => {
   const reports: ReportData[] = [
-    {
-      name: "گزارش حقوق ماهیانه",
-      type: "PDF",
-      period: "آذر ۱۴۰۵",
-      status: "ready",
-      generated: "۱۴۰۵-۰۶-۱۵",
-    },
-    {
-      name: "گزارش کسورات",
-      type: "Excel",
-      period: "آذر ۱۴۰۵",
-      status: "ready",
-      generated: "۱۴۰۵-۰۶-۱۵",
-    },
-    {
-      name: "گزارش بیمه و تأمین‌اجتماعی",
-      type: "PDF",
-      period: "آذر ۱۴۰۵",
-      status: "processing",
-      generated: "—",
-    },
-    {
-      name: "گزارش تجدید‌نظر حقوق",
-      type: "Excel",
-      period: "دی ۱۴۰۵",
-      status: "ready",
-      generated: "۱۴۰۵-۰۶-۱۴",
-    },
+    { name: "گزارش حقوق ماهیانه", type: "PDF", period: "آذر ۱۴۰۵", status: "ready", generated: "۱۴۰۵-۰۶-۱۵" },
+    { name: "گزارش کسورات", type: "Excel", period: "آذر ۱۴۰۵", status: "ready", generated: "۱۴۰۵-۰۶-۱۵" },
+    { name: "گزارش بیمه و تأمین‌اجتماعی", type: "PDF", period: "آذر ۱۴۰۵", status: "processing", generated: "—" },
+    { name: "گزارش تجدید‌نظر حقوق", type: "Excel", period: "دی ۱۴۰۵", status: "ready", generated: "۱۴۰۵-۰۶-۱۴" },
   ];
 
   const chartData = [
@@ -51,99 +27,45 @@ const Reports: React.FC = () => {
     { month: "فروردین", processed: 242, pending: 6, rejected: 2 },
   ];
 
-  const stats = {
-    totalReports: 24,
-    thisMonth: 5,
-    avgTime: "۲.۳ روز",
-    successRate: "۹۸.۵%",
-  };
+  const stats = { totalReports: 24, thisMonth: 5, avgTime: "۲.۳ روز", successRate: "۹۸.۵%" };
 
   return (
     <div className="min-h-screen bg-gray-50 p-4 md:p-8">
       <div className="max-w-7xl mx-auto">
-        {/* Header */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900">گزارش‌ها</h1>
-          <p className="text-gray-600 mt-2">
-            تولید و مدیریت گزارش‌های تحلیلی و مالی
-          </p>
+          <p className="text-gray-600 mt-2">تولید و مدیریت گزارش‌های تحلیلی و مالی</p>
         </div>
 
-        {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-          <StatCard
-            title="کل گزارش‌ها"
-            value={stats.totalReports.toString()}
-            icon={<FileText className="w-8 h-8" />}
-            trend={`+ ${stats.thisMonth} این ماه`}
-            color="blue"
-          />
-          <StatCard
-            title="میزان موفقیت"
-            value={stats.successRate}
-            icon={<TrendingUp className="w-8 h-8" />}
-            trend="▲ ۱.۲%"
-            color="green"
-          />
-          <StatCard
-            title="میانگین زمان"
-            value={stats.avgTime}
-            icon={<BarChart3 className="w-8 h-8" />}
-            trend="▼ ۰.۳ روز"
-            color="indigo"
-          />
-          <StatCard
-            title="گزارش درحال‌پردازش"
-            value="۳"
-            icon={<FileText className="w-8 h-8" />}
-            trend="کاملاً سریع"
-            color="orange"
-          />
+          <StatCard title="کل گزارش‌ها" value={stats.totalReports.toString()} icon={FileText} trend={`+ ${stats.thisMonth} این ماه`} color="blue" />
+          <StatCard title="میزان موفقیت" value={stats.successRate} icon={TrendingUp} trend="▲ ۱.۲%" color="green" />
+          <StatCard title="میانگین زمان" value={stats.avgTime} icon={BarChart3} trend="▼ ۰.۳ روز" color="blue" />
+          <StatCard title="گزارش درحال‌پردازش" value="۳" icon={FileText} trend="کاملاً سریع" color="orange" />
         </div>
 
-        {/* Chart */}
         <div className="bg-white rounded-lg shadow p-6 mb-8">
-          <h2 className="text-xl font-bold text-gray-900 mb-4">
-            روند گزارش‌های ماهیانه
-          </h2>
+          <h2 className="text-xl font-bold text-gray-900 mb-4">روند گزارش‌های ماهیانه</h2>
           <PayrollChart data={chartData} />
         </div>
 
-        {/* Reports List */}
         <div className="grid grid-cols-1 gap-4">
-          {reports.map((report, idx) => (
-            <div
-              key={idx}
-              className="bg-white rounded-lg shadow p-6 flex items-center justify-between hover:shadow-lg transition-shadow"
-            >
+          {reports.map((report) => (
+            <div key={`${report.name}-${report.period}`} className="bg-white rounded-lg shadow p-6 flex items-center justify-between hover:shadow-lg transition-shadow">
               <div className="flex-1">
-                <h3 className="text-lg font-bold text-gray-900">
-                  {report.name}
-                </h3>
+                <h3 className="text-lg font-bold text-gray-900">{report.name}</h3>
                 <div className="flex gap-4 mt-2 text-sm text-gray-600">
                   <span>دوره: {report.period}</span>
                   <span>نوع: {report.type}</span>
-                  {report.generated !== "—" && (
-                    <span>تاریخ: {report.generated}</span>
-                  )}
+                  {report.generated !== "—" && <span>تاریخ: {report.generated}</span>}
                 </div>
               </div>
               <div className="flex items-center gap-4">
-                <span
-                  className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium ${
-                    report.status === "ready"
-                      ? "bg-green-100 text-green-800"
-                      : "bg-orange-100 text-orange-800"
-                  }`}
-                >
+                <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium ${report.status === "ready" ? "bg-green-100 text-green-800" : "bg-orange-100 text-orange-800"}`}>
                   {report.status === "ready" ? "آماده" : "درحال‌پردازش"}
                 </span>
                 <button
-                  className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                    report.status === "ready"
-                      ? "bg-blue-100 text-blue-700 hover:bg-blue-200"
-                      : "bg-gray-100 text-gray-500 cursor-not-allowed"
-                  }`}
+                  className={`px-4 py-2 rounded-lg font-medium transition-colors ${report.status === "ready" ? "bg-blue-100 text-blue-700 hover:bg-blue-200" : "bg-gray-100 text-gray-500 cursor-not-allowed"}`}
                   disabled={report.status !== "ready"}
                 >
                   {report.status === "ready" ? "دانلود" : "در انتظار..."}

--- a/web/src/pages/SelfService.tsx
+++ b/web/src/pages/SelfService.tsx
@@ -1,68 +1,168 @@
-import React from 'react';
-import { FileText, Download, BriefcaseBusiness, UserRound } from 'lucide-react';
-import { selfService } from '@/services/self-service';
+import React, { useState } from 'react';
+import { BriefcaseBusiness, Download, FileText, UserRound, X } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
+import { selfService } from '@/services/self-service';
 
 const money = (value: string) => new Intl.NumberFormat('fa-IR').format(Number(value));
+const date = (value: string) => new Intl.DateTimeFormat('fa-IR').format(new Date(value));
 
 function SelfService() {
-  const profile = useQuery({ queryKey: ['self', 'profile'], queryFn: selfService.getProfile });
-  const payslips = useQuery({ queryKey: ['self', 'payslips'], queryFn: () => selfService.getPayslips() });
-  const orders = useQuery({ queryKey: ['self', 'orders'], queryFn: selfService.getOrders });
+  const [period, setPeriod] = useState('');
+  const [selectedPayslipId, setSelectedPayslipId] = useState<string | null>(null);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
 
-  const downloadPdf = async (artifactId: string, period: string) => {
-    const response = await selfService.getPayslipPdf(artifactId);
-    const blob = response instanceof Blob ? response : new Blob([response as BlobPart]);
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement('a');
-    anchor.href = url;
-    anchor.download = `payslip-${period}.pdf`;
-    anchor.click();
-    URL.revokeObjectURL(url);
+  const profile = useQuery({ queryKey: ['self', 'profile'], queryFn: selfService.getProfile });
+  const payslips = useQuery({
+    queryKey: ['self', 'payslips', period],
+    queryFn: () => selfService.getPayslips(period || undefined),
+  });
+  const orders = useQuery({ queryKey: ['self', 'orders'], queryFn: selfService.getOrders });
+  const selectedPayslip = useQuery({
+    queryKey: ['self', 'payslip', selectedPayslipId],
+    queryFn: () => selfService.getPayslip(selectedPayslipId as string),
+    enabled: Boolean(selectedPayslipId),
+  });
+
+  const downloadPdf = async (artifactId: string, payslipPeriod: string) => {
+    setDownloadError(null);
+    setDownloadingId(artifactId);
+    try {
+      const response = await selfService.getPayslipPdf(artifactId);
+      const blob = response instanceof Blob ? response : new Blob([response as BlobPart], { type: 'application/pdf' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `payslip-${payslipPeriod}.pdf`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+    } catch {
+      setDownloadError('دریافت فایل PDF ناموفق بود. وضعیت فیش را بررسی کرده و دوباره تلاش کنید.');
+    } finally {
+      setDownloadingId(null);
+    }
   };
 
   const profileData = profile.data?.data;
   const payslipItems = payslips.data?.data ?? [];
   const orderItems = orders.data?.data ?? [];
+  const detail = selectedPayslip.data?.data;
 
   return (
-    <div className="p-6 space-y-6" dir="rtl">
-      <div>
+    <div className="space-y-6 p-6" dir="rtl">
+      <header>
         <h1 className="text-3xl font-bold text-morva-900">خدمات کارکنان</h1>
-        <p className="text-morva-600 mt-2">نمایش اطلاعات شخصی، فیش حقوقی و احکام فقط از مسیر احراز‌شده سامانه.</p>
-      </div>
+        <p className="mt-2 text-morva-600">اطلاعات شخصی، فیش حقوقی و احکام فقط از مسیر احراز‌شده سامانه.</p>
+      </header>
 
-      {profile.isError && <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-800">دریافت پروفایل ناموفق بود.</div>}
+      {profile.isError && <div role="alert" className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-800">دریافت پروفایل ناموفق بود.</div>}
+      {profile.isLoading && <div className="rounded-xl border border-morva-200 bg-white p-4 text-sm text-morva-600">در حال دریافت پروفایل…</div>}
       {profileData && (
-        <section className="bg-white rounded-xl border border-morva-200 p-6 shadow-sm">
-          <div className="flex items-center gap-3 mb-4"><UserRound size={22} /><h2 className="text-lg font-bold">پروفایل پرسنلی</h2></div>
-          <div className="grid md:grid-cols-3 gap-4 text-sm">
-            <div><span className="text-morva-500">نام</span><div className="font-semibold mt-1">{profileData.first_name} {profileData.last_name}</div></div>
-            <div><span className="text-morva-500">کد کارمند</span><div className="font-semibold mt-1">{profileData.employee_no}</div></div>
-            <div><span className="text-morva-500">وضعیت</span><div className="font-semibold mt-1">{profileData.status}</div></div>
+        <section className="rounded-xl border border-morva-200 bg-white p-6 shadow-sm">
+          <div className="mb-4 flex items-center gap-3"><UserRound size={22} /><h2 className="text-lg font-bold">پروفایل پرسنلی</h2></div>
+          <div className="grid gap-4 text-sm md:grid-cols-4">
+            <div><span className="text-morva-500">نام</span><div className="mt-1 font-semibold">{profileData.first_name} {profileData.last_name}</div></div>
+            <div><span className="text-morva-500">کد کارمند</span><div className="mt-1 font-semibold">{profileData.employee_no}</div></div>
+            <div><span className="text-morva-500">نوع استخدام</span><div className="mt-1 font-semibold">{profileData.employment_type}</div></div>
+            <div><span className="text-morva-500">وضعیت</span><div className="mt-1 font-semibold">{profileData.status}</div></div>
           </div>
         </section>
       )}
 
-      <section className="bg-white rounded-xl border border-morva-200 p-6 shadow-sm">
-        <div className="flex items-center gap-3 mb-4"><FileText size={22} /><h2 className="text-lg font-bold">فیش‌های حقوقی</h2></div>
-        {payslips.isLoading && <p className="text-sm text-morva-600">در حال دریافت…</p>}
-        {payslips.isError && <p className="text-sm text-red-700">دریافت فیش‌ها ناموفق بود.</p>}
+      <section className="rounded-xl border border-morva-200 bg-white p-6 shadow-sm">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3"><FileText size={22} /><h2 className="text-lg font-bold">فیش‌های حقوقی</h2></div>
+          <label className="flex items-center gap-2 text-sm">
+            <span className="text-morva-600">دوره</span>
+            <input
+              value={period}
+              onChange={(event) => setPeriod(event.target.value)}
+              placeholder="۱۴۰۵-۰۶"
+              inputMode="numeric"
+              aria-label="دوره فیش حقوقی"
+              className="w-32 rounded-lg border border-morva-300 px-3 py-2 text-right"
+            />
+            {period && <button type="button" onClick={() => setPeriod('')} className="text-sm font-semibold text-morva-700">حذف فیلتر</button>}
+          </label>
+        </div>
+
+        {downloadError && <div role="alert" className="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800">{downloadError}</div>}
+        {payslips.isLoading && <p className="text-sm text-morva-600">در حال دریافت فیش‌ها…</p>}
+        {payslips.isError && <p role="alert" className="text-sm text-red-700">دریافت فیش‌ها ناموفق بود.</p>}
         {!payslips.isLoading && !payslips.isError && payslipItems.length === 0 && <p className="text-sm text-morva-600">فیش قابل نمایش وجود ندارد.</p>}
         {payslipItems.length > 0 && (
-          <div className="overflow-x-auto"><table className="w-full text-sm"><thead><tr className="border-b border-morva-200 text-right"><th className="px-3 py-3">دوره</th><th className="px-3 py-3">ناخالص</th><th className="px-3 py-3">کسورات</th><th className="px-3 py-3">خالص</th><th className="px-3 py-3">عملیات</th></tr></thead><tbody>
-            {payslipItems.map((item) => <tr key={item.artifact_id} className="border-b border-morva-100"><td className="px-3 py-3">{item.period}</td><td className="px-3 py-3">{money(item.gross)}</td><td className="px-3 py-3">{money(item.deductions)}</td><td className="px-3 py-3 font-semibold">{money(item.net)}</td><td className="px-3 py-3"><button onClick={() => downloadPdf(item.artifact_id, item.period)} className="inline-flex items-center gap-2 rounded-lg bg-morva-600 px-3 py-2 text-white hover:bg-morva-700"><Download size={16} /> PDF</button></td></tr>)}
-          </tbody></table></div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead><tr className="border-b border-morva-200 text-right"><th className="px-3 py-3">دوره</th><th className="px-3 py-3">وضعیت</th><th className="px-3 py-3">ناخالص</th><th className="px-3 py-3">کسورات</th><th className="px-3 py-3">خالص</th><th className="px-3 py-3">عملیات</th></tr></thead>
+              <tbody>
+                {payslipItems.map((item) => (
+                  <tr key={item.artifact_id} className="border-b border-morva-100">
+                    <td className="px-3 py-3 font-medium">{item.period}</td>
+                    <td className="px-3 py-3">{item.status}</td>
+                    <td className="px-3 py-3">{money(item.gross)} {item.currency_code}</td>
+                    <td className="px-3 py-3">{money(item.deductions)} {item.currency_code}</td>
+                    <td className="px-3 py-3 font-semibold">{money(item.net)} {item.currency_code}</td>
+                    <td className="px-3 py-3">
+                      <div className="flex flex-wrap gap-2">
+                        <button type="button" onClick={() => setSelectedPayslipId(item.artifact_id)} className="rounded-lg border border-morva-300 px-3 py-2 font-semibold text-morva-800 hover:bg-morva-50">جزئیات</button>
+                        <button
+                          type="button"
+                          disabled={downloadingId === item.artifact_id}
+                          onClick={() => downloadPdf(item.artifact_id, item.period)}
+                          className="inline-flex items-center gap-2 rounded-lg bg-morva-600 px-3 py-2 text-white hover:bg-morva-700 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          <Download size={16} />{downloadingId === item.artifact_id ? 'در حال دریافت…' : 'PDF'}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </section>
 
-      <section className="bg-white rounded-xl border border-morva-200 p-6 shadow-sm">
-        <div className="flex items-center gap-3 mb-4"><BriefcaseBusiness size={22} /><h2 className="text-lg font-bold">احکام پرسنلی</h2></div>
-        {orders.isLoading && <p className="text-sm text-morva-600">در حال دریافت…</p>}
-        {orders.isError && <p className="text-sm text-red-700">دریافت احکام ناموفق بود.</p>}
+      <section className="rounded-xl border border-morva-200 bg-white p-6 shadow-sm">
+        <div className="mb-4 flex items-center gap-3"><BriefcaseBusiness size={22} /><h2 className="text-lg font-bold">احکام پرسنلی</h2></div>
+        {orders.isLoading && <p className="text-sm text-morva-600">در حال دریافت احکام…</p>}
+        {orders.isError && <p role="alert" className="text-sm text-red-700">دریافت احکام ناموفق بود.</p>}
         {!orders.isLoading && !orders.isError && orderItems.length === 0 && <p className="text-sm text-morva-600">حکم قابل نمایش وجود ندارد.</p>}
-        {orderItems.length > 0 && <div className="space-y-3">{orderItems.map((order) => <div key={order.order_no} className="rounded-lg border border-morva-100 p-4"><div className="font-semibold">{order.order_no} — {order.order_type}</div><div className="text-xs text-morva-600 mt-1">تاریخ اجرا: {order.effective_date}</div><div className="text-sm mt-2">{order.reason || 'بدون شرح ثبت‌شده'}</div></div>)}</div>}
+        {orderItems.length > 0 && <div className="space-y-3">{orderItems.map((order) => <div key={order.order_no} className="rounded-lg border border-morva-100 p-4"><div className="font-semibold">{order.order_no} — {order.order_type}</div><div className="mt-1 text-xs text-morva-600">تاریخ صدور: {date(order.issue_date)} | تاریخ اجرا: {date(order.effective_date)}</div><div className="mt-2 text-sm">{order.reason || 'بدون شرح ثبت‌شده'}</div>{order.legal_reference && <div className="mt-2 text-xs text-morva-500">مرجع: {order.legal_reference}</div>}</div>)}</div>}
       </section>
+
+      {selectedPayslipId && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" role="presentation" onMouseDown={(event) => { if (event.target === event.currentTarget) setSelectedPayslipId(null); }}>
+          <section aria-label="جزئیات فیش حقوقی" className="max-h-[90vh] w-full max-w-4xl overflow-y-auto rounded-2xl bg-white p-6 shadow-xl">
+            <div className="mb-5 flex items-center justify-between gap-4"><h2 className="text-xl font-bold">جزئیات فیش حقوقی</h2><button type="button" aria-label="بستن" onClick={() => setSelectedPayslipId(null)} className="rounded-lg p-2 hover:bg-morva-100"><X size={20} /></button></div>
+            {selectedPayslip.isLoading && <p className="text-sm text-morva-600">در حال دریافت جزئیات…</p>}
+            {selectedPayslip.isError && <p role="alert" className="text-sm text-red-700">دریافت جزئیات فیش ناموفق بود.</p>}
+            {detail && (
+              <div className="space-y-5">
+                <div className="grid gap-3 rounded-xl border border-morva-200 bg-morva-50 p-4 text-sm md:grid-cols-4">
+                  <div><span className="text-morva-500">دوره</span><div className="font-semibold">{detail.period}</div></div>
+                  <div><span className="text-morva-500">وضعیت</span><div className="font-semibold">{detail.status}</div></div>
+                  <div><span className="text-morva-500">نسخه Rule Pack</span><div className="font-semibold">{detail.rule_pack_version}</div></div>
+                  <div><span className="text-morva-500">خالص</span><div className="font-semibold">{money(detail.net)} {detail.currency_code}</div></div>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm"><thead><tr className="border-b border-morva-200 text-right"><th className="px-3 py-2">ردیف</th><th className="px-3 py-2">عنوان</th><th className="px-3 py-2">مبلغ</th><th className="px-3 py-2">نوع</th><th className="px-3 py-2">توضیح</th></tr></thead><tbody>
+                    {(detail.lines ?? []).map((line) => <tr key={`${line.sequence}-${line.code}`} className="border-b border-morva-100"><td className="px-3 py-2">{line.sequence}</td><td className="px-3 py-2 font-medium">{line.title}</td><td className="px-3 py-2">{money(line.amount)} {detail.currency_code}</td><td className="px-3 py-2">{line.kind}</td><td className="px-3 py-2">{line.explanation || 'بدون توضیح ثبت‌شده'}</td></tr>)}
+                  </tbody></table>
+                </div>
+                <div className="grid gap-3 rounded-xl border border-morva-200 p-4 text-xs text-morva-700 md:grid-cols-2">
+                  <div><div className="font-semibold">شناسه Snapshot</div><div className="mt-1 break-all">{detail.personnel_snapshot_id || 'ثبت نشده'}</div></div>
+                  <div><div className="font-semibold">Hash Snapshot</div><div className="mt-1 break-all">{detail.personnel_snapshot_hash}</div></div>
+                  <div><div className="font-semibold">Input Hash</div><div className="mt-1 break-all">{detail.input_hash || 'ثبت نشده'}</div></div>
+                  <div><div className="font-semibold">Output Hash</div><div className="mt-1 break-all">{detail.output_hash}</div></div>
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/pages/SelfService.tsx
+++ b/web/src/pages/SelfService.tsx
@@ -29,7 +29,9 @@ function SelfService() {
     setDownloadingId(artifactId);
     try {
       const response = await selfService.getPayslipPdf(artifactId);
-      const blob = response instanceof Blob ? response : new Blob([response as BlobPart], { type: 'application/pdf' });
+      const blob = response instanceof Blob
+        ? response
+        : new Blob([response as unknown as BlobPart], { type: 'application/pdf' });
       const url = URL.createObjectURL(blob);
       const anchor = document.createElement('a');
       anchor.href = url;
@@ -76,14 +78,7 @@ function SelfService() {
           <div className="flex items-center gap-3"><FileText size={22} /><h2 className="text-lg font-bold">فیش‌های حقوقی</h2></div>
           <label className="flex items-center gap-2 text-sm">
             <span className="text-morva-600">دوره</span>
-            <input
-              value={period}
-              onChange={(event) => setPeriod(event.target.value)}
-              placeholder="۱۴۰۵-۰۶"
-              inputMode="numeric"
-              aria-label="دوره فیش حقوقی"
-              className="w-32 rounded-lg border border-morva-300 px-3 py-2 text-right"
-            />
+            <input value={period} onChange={(event) => setPeriod(event.target.value)} placeholder="۱۴۰۵-۰۶" inputMode="numeric" aria-label="دوره فیش حقوقی" className="w-32 rounded-lg border border-morva-300 px-3 py-2 text-right" />
             {period && <button type="button" onClick={() => setPeriod('')} className="text-sm font-semibold text-morva-700">حذف فیلتر</button>}
           </label>
         </div>
@@ -107,12 +102,7 @@ function SelfService() {
                     <td className="px-3 py-3">
                       <div className="flex flex-wrap gap-2">
                         <button type="button" onClick={() => setSelectedPayslipId(item.artifact_id)} className="rounded-lg border border-morva-300 px-3 py-2 font-semibold text-morva-800 hover:bg-morva-50">جزئیات</button>
-                        <button
-                          type="button"
-                          disabled={downloadingId === item.artifact_id}
-                          onClick={() => downloadPdf(item.artifact_id, item.period)}
-                          className="inline-flex items-center gap-2 rounded-lg bg-morva-600 px-3 py-2 text-white hover:bg-morva-700 disabled:cursor-not-allowed disabled:opacity-60"
-                        >
+                        <button type="button" disabled={downloadingId === item.artifact_id} onClick={() => downloadPdf(item.artifact_id, item.period)} className="inline-flex items-center gap-2 rounded-lg bg-morva-600 px-3 py-2 text-white hover:bg-morva-700 disabled:cursor-not-allowed disabled:opacity-60">
                           <Download size={16} />{downloadingId === item.artifact_id ? 'در حال دریافت…' : 'PDF'}
                         </button>
                       </div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import StatCard from "@/components/ui/StatCard";
-import { Settings, Lock, Bell, Database, Shield } from "lucide-react";
+import { Settings as SettingsIcon, Lock, Bell, Database, Shield } from "lucide-react";
 
 interface SettingGroup {
   name: string;
@@ -29,10 +29,7 @@ const Settings: React.FC = () => {
       description: "مدیریت اطلاعیه‌های سیستم",
       icon: <Bell className="w-6 h-6" />,
       items: [
-        {
-          label: "اطلاعیه‌های درون‌برنامه",
-          value: settings.notifications,
-        },
+        { label: "اطلاعیه‌های درون‌برنامه", value: settings.notifications },
         { label: "اطلاعیه‌های ایمیل", value: settings.emailNotifications },
       ],
     },
@@ -40,17 +37,13 @@ const Settings: React.FC = () => {
       name: "امنیت",
       description: "تنظیمات امنیتی حساب",
       icon: <Shield className="w-6 h-6" />,
-      items: [
-        { label: "تأیید دورمرحله‌ای", value: settings.twoFactor },
-      ],
+      items: [{ label: "تأیید دورمرحله‌ای", value: settings.twoFactor }],
     },
     {
       name: "داده‌ها",
       description: "مدیریت و بکاپ داده‌ها",
       icon: <Database className="w-6 h-6" />,
-      items: [
-        { label: "پشتیبان‌گیری خودکار", value: settings.dataBackup },
-      ],
+      items: [{ label: "پشتیبان‌گیری خودکار", value: settings.dataBackup }],
     },
   ];
 
@@ -70,90 +63,44 @@ const Settings: React.FC = () => {
   return (
     <div className="min-h-screen bg-gray-50 p-4 md:p-8">
       <div className="max-w-7xl mx-auto">
-        {/* Header */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900">تنظیمات</h1>
-          <p className="text-gray-600 mt-2">
-            مدیریت تنظیمات سیستم و حساب کاربری
-          </p>
+          <p className="text-gray-600 mt-2">مدیریت تنظیمات سیستم و حساب کاربری</p>
         </div>
 
-        {/* Security Stats */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-          <StatCard
-            title="امتیاز امنیتی"
-            value={stats.securityScore}
-            icon={<Shield className="w-8 h-8" />}
-            trend="عالی"
-            color="green"
-          />
-          <StatCard
-            title="آخرین پشتیبان‌گیری"
-            value={stats.lastBackup}
-            icon={<Database className="w-8 h-8" />}
-            trend="امروز"
-            color="blue"
-          />
-          <StatCard
-            title="عمر حساب"
-            value={stats.accountAge}
-            icon={<Lock className="w-8 h-8" />}
-            trend="فعال"
-            color="indigo"
-          />
-          <StatCard
-            title="وضعیت سیستم"
-            value="سالم"
-            icon={<Settings className="w-8 h-8" />}
-            trend="۱۰۰%"
-            color="green"
-          />
+          <StatCard title="امتیاز امنیتی" value={stats.securityScore} icon={Shield} trend="عالی" color="green" />
+          <StatCard title="آخرین پشتیبان‌گیری" value={stats.lastBackup} icon={Database} trend="امروز" color="blue" />
+          <StatCard title="عمر حساب" value={stats.accountAge} icon={Lock} trend="فعال" color="blue" />
+          <StatCard title="وضعیت سیستم" value="سالم" icon={SettingsIcon} trend="۱۰۰%" color="green" />
         </div>
 
-        {/* Settings Groups */}
         <div className="space-y-6">
           {settingGroups.map((group, idx) => (
             <div key={idx} className="bg-white rounded-lg shadow overflow-hidden">
               <div className="px-6 py-4 border-b border-gray-200 flex items-center gap-4">
                 <div className="text-blue-600">{group.icon}</div>
                 <div>
-                  <h2 className="text-xl font-bold text-gray-900">
-                    {group.name}
-                  </h2>
+                  <h2 className="text-xl font-bold text-gray-900">{group.name}</h2>
                   <p className="text-sm text-gray-600">{group.description}</p>
                 </div>
               </div>
               <div className="p-6 space-y-4">
                 {group.items.map((item, itemIdx) => (
-                  <div
-                    key={itemIdx}
-                    className="flex items-center justify-between p-4 hover:bg-gray-50 rounded-lg"
-                  >
-                    <span className="font-medium text-gray-900">
-                      {item.label}
-                    </span>
+                  <div key={itemIdx} className="flex items-center justify-between p-4 hover:bg-gray-50 rounded-lg">
+                    <span className="font-medium text-gray-900">{item.label}</span>
                     {typeof item.value === "boolean" && (
                       <button
+                        type="button"
                         onClick={() => {
-                          if (item.label === "اطلاعیه‌های درون‌برنامه") {
-                            toggleSetting("notifications");
-                          } else if (item.label === "اطلاعیه‌های ایمیل") {
-                            toggleSetting("emailNotifications");
-                          } else if (item.label === "تأیید دورمرحله‌ای") {
-                            toggleSetting("twoFactor");
-                          } else if (item.label === "پشتیبان‌گیری خودکار") {
-                            toggleSetting("dataBackup");
-                          }
+                          if (item.label === "اطلاعیه‌های درون‌برنامه") toggleSetting("notifications");
+                          else if (item.label === "اطلاعیه‌های ایمیل") toggleSetting("emailNotifications");
+                          else if (item.label === "تأیید دورمرحله‌ای") toggleSetting("twoFactor");
+                          else if (item.label === "پشتیبان‌گیری خودکار") toggleSetting("dataBackup");
                         }}
-                        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                          item.value ? "bg-green-600" : "bg-gray-300"
-                        }`}
+                        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${item.value ? "bg-green-600" : "bg-gray-300"}`}
                       >
-                        <span
-                          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                            item.value ? "translate-x-6" : "translate-x-1"
-                          }`}
-                        />
+                        <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${item.value ? "translate-x-6" : "translate-x-1"}`} />
                       </button>
                     )}
                   </div>
@@ -163,14 +110,9 @@ const Settings: React.FC = () => {
           ))}
         </div>
 
-        {/* Save Button */}
         <div className="mt-8 flex justify-end gap-4">
-          <button className="px-6 py-2 border border-gray-300 text-gray-900 font-medium rounded-lg hover:bg-gray-50 transition-colors">
-            انصراف
-          </button>
-          <button className="px-6 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors">
-            ذخیره تنظیمات
-          </button>
+          <button className="px-6 py-2 border border-gray-300 text-gray-900 font-medium rounded-lg hover:bg-gray-50 transition-colors">انصراف</button>
+          <button className="px-6 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors">ذخیره تنظیمات</button>
         </div>
       </div>
     </div>

--- a/web/src/services/queries.ts
+++ b/web/src/services/queries.ts
@@ -52,7 +52,7 @@ export function useLogin(options?: UseMutationOptions<any, Error, types.LoginReq
   });
 }
 
-export function useLogout(options?: UseMutationOptions<void, Error, void>) {
+export function useLogout(options?: UseMutationOptions<types.ApiResponse<unknown>, Error, void>) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: authService.logout,

--- a/web/src/services/queries.ts
+++ b/web/src/services/queries.ts
@@ -19,8 +19,6 @@ import {
 } from '.';
 import * as types from '../types/api';
 
-// ============= Query Key Factory =============
-
 export const queryKeys = {
   all: ['api'] as const,
   auth: () => [...queryKeys.all, 'auth'] as const,
@@ -43,261 +41,112 @@ export const queryKeys = {
   report: (id: string) => [...queryKeys.reports(), id] as const,
 };
 
-// ============= Auth Hooks =============
-
 export function useLogin(options?: UseMutationOptions<any, Error, types.LoginRequest>) {
-  return useMutation({
-    mutationFn: authService.login,
-    ...options,
-  });
+  return useMutation({ mutationFn: authService.login, ...options });
 }
 
-export function useLogout(options?: UseMutationOptions<types.ApiResponse<unknown>, Error, void>) {
+export function useLogout(options?: UseMutationOptions<void, Error, void>) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: authService.logout,
-    onSuccess: () => {
-      queryClient.clear();
-    },
+    onSuccess: () => { queryClient.clear(); },
     ...options,
   });
 }
 
 export function useAuthMe(options?: UseQueryOptions<any>) {
-  return useQuery({
-    queryKey: queryKeys.authMe(),
-    queryFn: authService.getProfile,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    ...options,
-  });
+  return useQuery({ queryKey: queryKeys.authMe(), queryFn: authService.getProfile, staleTime: 5 * 60 * 1000, ...options });
 }
 
-// ============= Employee Hooks =============
-
-export function useEmployees(
-  filters?: types.EmployeeFilters,
-  options?: UseQueryOptions<any>
-) {
-  return useQuery({
-    queryKey: queryKeys.employeesList(filters),
-    queryFn: () => employeeService.getAll(filters),
-    staleTime: 2 * 60 * 1000, // 2 minutes
-    ...options,
-  });
+export function useEmployees(filters?: types.EmployeeFilters, options?: UseQueryOptions<any>) {
+  return useQuery({ queryKey: queryKeys.employeesList(filters), queryFn: () => employeeService.getAll(filters), staleTime: 2 * 60 * 1000, ...options });
 }
 
 export function useEmployee(id: string, options?: UseQueryOptions<any>) {
-  return useQuery({
-    queryKey: queryKeys.employee(id),
-    queryFn: () => employeeService.getById(id),
-    staleTime: 5 * 60 * 1000,
-    ...options,
-  });
+  return useQuery({ queryKey: queryKeys.employee(id), queryFn: () => employeeService.getById(id), staleTime: 5 * 60 * 1000, ...options });
 }
 
 export function useCreateEmployee(options?: UseMutationOptions<any, Error, types.CreateEmployeeDto>) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: employeeService.create,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.employeesList() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.employeesStats() });
-    },
-    ...options,
-  });
+  return useMutation({ mutationFn: employeeService.create, onSuccess: () => { queryClient.invalidateQueries({ queryKey: queryKeys.employeesList() }); queryClient.invalidateQueries({ queryKey: queryKeys.employeesStats() }); }, ...options });
 }
 
 export function useUpdateEmployee(id: string, options?: UseMutationOptions<any, Error, types.UpdateEmployeeDto>) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (data) => employeeService.update(id, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.employee(id) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.employeesList() });
-    },
-    ...options,
-  });
+  return useMutation({ mutationFn: (data) => employeeService.update(id, data), onSuccess: () => { queryClient.invalidateQueries({ queryKey: queryKeys.employee(id) }); queryClient.invalidateQueries({ queryKey: queryKeys.employeesList() }); }, ...options });
 }
 
-export function useDeleteEmployee(id: string, options?: UseMutationOptions<void, Error, void>) {
+export function useDeleteEmployee(id: string, options?: UseMutationOptions<types.ApiResponse<unknown>, Error, void>) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: () => employeeService.delete(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.employeesList() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.employeesStats() });
-    },
-    ...options,
-  });
+  return useMutation({ mutationFn: () => employeeService.delete(id), onSuccess: () => { queryClient.invalidateQueries({ queryKey: queryKeys.employeesList() }); queryClient.invalidateQueries({ queryKey: queryKeys.employeesStats() }); }, ...options });
 }
 
 export function useEmployeeStats(options?: UseQueryOptions<any>) {
-  return useQuery({
-    queryKey: queryKeys.employeesStats(),
-    queryFn: employeeService.getStats,
-    staleTime: 5 * 60 * 1000,
-    ...options,
-  });
+  return useQuery({ queryKey: queryKeys.employeesStats(), queryFn: employeeService.getStats, staleTime: 5 * 60 * 1000, ...options });
 }
 
-// ============= Payroll Hooks =============
-
-export function usePayrolls(
-  filters?: types.PayrollFilters,
-  options?: UseQueryOptions<any>
-) {
-  return useQuery({
-    queryKey: queryKeys.payrollList(filters),
-    queryFn: () => payrollService.getAll(filters),
-    staleTime: 2 * 60 * 1000,
-    ...options,
-  });
+export function usePayrolls(filters?: types.PayrollFilters, options?: UseQueryOptions<any>) {
+  return useQuery({ queryKey: queryKeys.payrollList(filters), queryFn: () => payrollService.getAll(filters), staleTime: 2 * 60 * 1000, ...options });
 }
 
 export function usePayroll(id: string, options?: UseQueryOptions<any>) {
-  return useQuery({
-    queryKey: queryKeys.payrollDetail(id),
-    queryFn: () => payrollService.getById(id),
-    staleTime: 3 * 60 * 1000,
-    ...options,
-  });
+  return useQuery({ queryKey: queryKeys.payrollDetail(id), queryFn: () => payrollService.getById(id), staleTime: 3 * 60 * 1000, ...options });
 }
 
 export function useCreatePayroll(options?: UseMutationOptions<any, Error, types.CreatePayrollDto>) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: payrollService.create,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.payrollList() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.payrollStats() });
-    },
-    ...options,
-  });
+  return useMutation({ mutationFn: payrollService.create, onSuccess: () => { queryClient.invalidateQueries({ queryKey: queryKeys.payrollList() }); queryClient.invalidateQueries({ queryKey: queryKeys.payrollStats() }); }, ...options });
 }
 
 export function useProcessPayroll(options?: UseMutationOptions<any, Error, types.ProcessPayrollDto>) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: payrollService.process,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.payrollList() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.payrollStats() });
-    },
-    ...options,
-  });
+  return useMutation({ mutationFn: payrollService.process, onSuccess: () => { queryClient.invalidateQueries({ queryKey: queryKeys.payrollList() }); queryClient.invalidateQueries({ queryKey: queryKeys.payrollStats() }); }, ...options });
 }
 
 export function useApprovePayroll(options?: UseMutationOptions<any, Error, types.ApprovePayrollDto>) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: payrollService.approve,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.payrollList() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.approvalsStats() });
-    },
-    ...options,
-  });
+  return useMutation({ mutationFn: payrollService.approve, onSuccess: () => { queryClient.invalidateQueries({ queryKey: queryKeys.payrollList() }); queryClient.invalidateQueries({ queryKey: queryKeys.approvalsStats() }); }, ...options });
 }
 
 export function usePayrollStats(options?: UseQueryOptions<any>) {
-  return useQuery({
-    queryKey: queryKeys.payrollStats(),
-    queryFn: payrollService.getStats,
-    staleTime: 5 * 60 * 1000,
-    ...options,
-  });
+  return useQuery({ queryKey: queryKeys.payrollStats(), queryFn: payrollService.getStats, staleTime: 5 * 60 * 1000, ...options });
 }
-
-// ============= Approval Hooks =============
 
 export function useApprovals(filters?: any, options?: UseQueryOptions<any>) {
-  return useQuery({
-    queryKey: queryKeys.approvalsList(filters),
-    queryFn: () => approvalService.getAll(filters),
-    staleTime: 1 * 60 * 1000, // 1 minute (more frequent updates)
-    ...options,
-  });
+  return useQuery({ queryKey: queryKeys.approvalsList(filters), queryFn: () => approvalService.getAll(filters), staleTime: 1 * 60 * 1000, ...options });
 }
 
-export function usePendingApprovals(filters?: any, options?: UseQueryOptions<any>) {
-  return useQuery({
-    queryKey: [...queryKeys.approvalsList(filters), 'pending'],
-    queryFn: () => approvalService.getPending(filters),
-    staleTime: 1 * 60 * 1000,
-    ...options,
-  });
+export function usePendingApprovals(filters?: any, options?: Omit<UseQueryOptions<any>, 'queryKey' | 'queryFn'>) {
+  return useQuery({ queryKey: [...queryKeys.approvalsList(filters), 'pending'], queryFn: () => approvalService.getPending(filters), staleTime: 1 * 60 * 1000, ...options });
 }
 
 export function useApproveRequest(options?: UseMutationOptions<any, Error, { approvalId: string; notes?: string }>) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ approvalId, notes }) => approvalService.approve(approvalId, notes),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.approvalsList() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.approvalsStats() });
-    },
-    ...options,
-  });
+  return useMutation({ mutationFn: ({ approvalId, notes }) => approvalService.approve(approvalId, notes), onSuccess: () => { queryClient.invalidateQueries({ queryKey: queryKeys.approvalsList() }); queryClient.invalidateQueries({ queryKey: queryKeys.approvalsStats() }); }, ...options });
 }
 
 export function useRejectRequest(options?: UseMutationOptions<any, Error, { approvalId: string; reason: string; notes?: string }>) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ approvalId, reason, notes }) => approvalService.reject(approvalId, reason, notes),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.approvalsList() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.approvalsStats() });
-    },
-    ...options,
-  });
+  return useMutation({ mutationFn: ({ approvalId, reason, notes }) => approvalService.reject(approvalId, reason, notes), onSuccess: () => { queryClient.invalidateQueries({ queryKey: queryKeys.approvalsList() }); queryClient.invalidateQueries({ queryKey: queryKeys.approvalsStats() }); }, ...options });
 }
 
 export function useApprovalsStats(options?: UseQueryOptions<any>) {
-  return useQuery({
-    queryKey: queryKeys.approvalsStats(),
-    queryFn: approvalService.getStats,
-    staleTime: 2 * 60 * 1000,
-    ...options,
-  });
+  return useQuery({ queryKey: queryKeys.approvalsStats(), queryFn: approvalService.getStats, staleTime: 2 * 60 * 1000, ...options });
 }
 
-// ============= Report Hooks =============
-
 export function useReports(filters?: any, options?: UseQueryOptions<any>) {
-  return useQuery({
-    queryKey: queryKeys.reportsList(filters),
-    queryFn: () => reportService.getAll(filters),
-    staleTime: 3 * 60 * 1000,
-    ...options,
-  });
+  return useQuery({ queryKey: queryKeys.reportsList(filters), queryFn: () => reportService.getAll(filters), staleTime: 3 * 60 * 1000, ...options });
 }
 
 export function useReport(id: string, options?: UseQueryOptions<any>) {
-  return useQuery({
-    queryKey: queryKeys.report(id),
-    queryFn: () => reportService.getById(id),
-    staleTime: 5 * 60 * 1000,
-    ...options,
-  });
+  return useQuery({ queryKey: queryKeys.report(id), queryFn: () => reportService.getById(id), staleTime: 5 * 60 * 1000, ...options });
 }
 
 export function useGenerateReport(options?: UseMutationOptions<any, Error, types.GenerateReportDto>) {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: reportService.generate,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.reportsList() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.reportsStats() });
-    },
-    ...options,
-  });
+  return useMutation({ mutationFn: reportService.generate, onSuccess: () => { queryClient.invalidateQueries({ queryKey: queryKeys.reportsList() }); queryClient.invalidateQueries({ queryKey: queryKeys.reportsStats() }); }, ...options });
 }
 
 export function useReportsStats(options?: UseQueryOptions<any>) {
-  return useQuery({
-    queryKey: queryKeys.reportsStats(),
-    queryFn: reportService.getStats,
-    staleTime: 5 * 60 * 1000,
-    ...options,
-  });
+  return useQuery({ queryKey: queryKeys.reportsStats(), queryFn: reportService.getStats, staleTime: 5 * 60 * 1000, ...options });
 }

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -3,9 +3,9 @@
  * Global test configuration and helpers
  */
 
-import { expect, afterEach, vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 
 // Cleanup after each test
 afterEach(() => {


### PR DESCRIPTION
## M3.16

Hardens the M3.15 employee self-service surface without introducing legal or payroll-rule assumptions.

### Included
- Period-filtered server-backed payslip listing
- On-demand payslip detail view with persisted line explanations and provenance hashes
- Explicit loading/error states and resilient PDF download lifecycle
- Localized Jalali-friendly date presentation for personnel orders
- Dedicated UI regression coverage for payslip detail and PDF failure handling
- Dedicated M3.16 web quality gate for type-check, Vitest and production build
- Roadmap and implementation matrix updates

### Governance boundary
- No rates, thresholds, formulas, legal treatments or external provider assumptions added.
- Existing authenticated self-service and fail-closed payroll/provenance checks remain authoritative.
- Production document-template certification, identity-directory reconciliation, retention policy and enterprise grievance/SLA evidence remain pending.