### PR TITLE
ci: cover M3.18 HR snapshot governance

### DIFF
--- a/.github/workflows/m3-17-personnel-order-lifecycle.yml
+++ b/.github/workflows/m3-17-personnel-order-lifecycle.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches: [main]
     paths:
+      - ".github/workflows/m3-17-personnel-order-lifecycle.yml"
       - "src/morva/personnel/order_integrity.py"
       - "src/morva/personnel/order_registry.py"
       - "src/morva/personnel/order_approval.py"
       - "src/morva/personnel/order_approval_policy.py"
+      - "src/morva/personnel/core_hr_snapshot.py"
       - "src/morva/api/v1/core_hr.py"
       - "src/morva/api/v1/order_approvals.py"
       - "src/morva/persistence/models.py"
@@ -21,13 +23,16 @@ on:
       - "tests/test_personnel_order_approval_policy.py"
       - "tests/test_personnel_order_approval_api.py"
       - "tests/test_personnel_orders_api.py"
+      - "tests/test_core_hr_snapshot_personnel_order_binding.py"
       - "docs/M3_17_PERSONNEL_ORDER_LIFECYCLE.md"
   pull_request:
     paths:
+      - ".github/workflows/m3-17-personnel-order-lifecycle.yml"
       - "src/morva/personnel/order_integrity.py"
       - "src/morva/personnel/order_registry.py"
       - "src/morva/personnel/order_approval.py"
       - "src/morva/personnel/order_approval_policy.py"
+      - "src/morva/personnel/core_hr_snapshot.py"
       - "src/morva/api/v1/core_hr.py"
       - "src/morva/api/v1/order_approvals.py"
       - "src/morva/persistence/models.py"
@@ -41,6 +46,7 @@ on:
       - "tests/test_personnel_order_approval_policy.py"
       - "tests/test_personnel_order_approval_api.py"
       - "tests/test_personnel_orders_api.py"
+      - "tests/test_core_hr_snapshot_personnel_order_binding.py"
       - "docs/M3_17_PERSONNEL_ORDER_LIFECYCLE.md"
 
 jobs:
@@ -53,10 +59,31 @@ jobs:
           python-version: "3.12"
       - name: Install dependencies
         run: python -m pip install -e '.[dev]'
-      - name: Lint personnel order governance
-        run: ruff check src/morva/personnel/order_integrity.py src/morva/personnel/order_registry.py src/morva/personnel/order_approval.py src/morva/personnel/order_approval_policy.py src/morva/api/v1/core_hr.py src/morva/api/v1/order_approvals.py tests/test_personnel_order_lifecycle_m3_10.py tests/test_personnel_order_effective_reconciliation.py tests/test_personnel_order_approval_policy.py tests/test_personnel_order_approval_api.py tests/test_personnel_orders_api.py
-      - name: Run personnel order governance tests
-        run: pytest -q tests/test_personnel_order_lifecycle_m3_10.py tests/test_personnel_order_effective_reconciliation.py tests/test_personnel_order_approval_policy.py tests/test_personnel_order_approval_api.py tests/test_personnel_orders_api.py
+      - name: Lint personnel order and snapshot governance
+        run: >-
+          ruff check
+          src/morva/personnel/order_integrity.py
+          src/morva/personnel/order_registry.py
+          src/morva/personnel/order_approval.py
+          src/morva/personnel/order_approval_policy.py
+          src/morva/personnel/core_hr_snapshot.py
+          src/morva/api/v1/core_hr.py
+          src/morva/api/v1/order_approvals.py
+          tests/test_personnel_order_lifecycle_m3_10.py
+          tests/test_personnel_order_effective_reconciliation.py
+          tests/test_personnel_order_approval_policy.py
+          tests/test_personnel_order_approval_api.py
+          tests/test_personnel_orders_api.py
+          tests/test_core_hr_snapshot_personnel_order_binding.py
+      - name: Run personnel order and snapshot governance tests
+        run: >-
+          pytest -q
+          tests/test_personnel_order_lifecycle_m3_10.py
+          tests/test_personnel_order_effective_reconciliation.py
+          tests/test_personnel_order_approval_policy.py
+          tests/test_personnel_order_approval_api.py
+          tests/test_personnel_orders_api.py
+          tests/test_core_hr_snapshot_personnel_order_binding.py
       - name: Validate migrations
         run: alembic upgrade head
       - name: Compile application

--- a/.github/workflows/m3-17-personnel-order-lifecycle.yml
+++ b/.github/workflows/m3-17-personnel-order-lifecycle.yml
@@ -85,8 +85,10 @@ jobs:
           tests/test_personnel_orders_api.py
           tests/test_core_hr_snapshot_personnel_order_binding.py
       - name: Validate migrations on a clean database
-        run: >-
+        env:
+          MORVA_DATABASE_URL: sqlite:///./migration-gate.db
+        run: |
           rm -f morva.db migration-gate.db
-          MORVA_DATABASE_URL=sqlite:///./migration-gate.db alembic upgrade head
+          alembic upgrade head
       - name: Compile application
         run: python -m compileall -q src tests

--- a/.github/workflows/m3-17-personnel-order-lifecycle.yml
+++ b/.github/workflows/m3-17-personnel-order-lifecycle.yml
@@ -84,7 +84,9 @@ jobs:
           tests/test_personnel_order_approval_api.py
           tests/test_personnel_orders_api.py
           tests/test_core_hr_snapshot_personnel_order_binding.py
-      - name: Validate migrations
-        run: alembic upgrade head
+      - name: Validate migrations on a clean database
+        run: >-
+          rm -f morva.db migration-gate.db
+          MORVA_DATABASE_URL=sqlite:///./migration-gate.db alembic upgrade head
       - name: Compile application
         run: python -m compileall -q src tests

--- a/tests/test_core_hr_snapshot_personnel_order_binding.py
+++ b/tests/test_core_hr_snapshot_personnel_order_binding.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from datetime import date
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -55,6 +55,7 @@ def _policy(session):
         source_reference="ORG-POLICY-SNAPSHOT-01",
         source_hash="a" * 64,
         approved_by="authority-1",
+        approved_at=datetime.now(timezone.utc),
     )
 
 

--- a/tests/test_masterdata_acceptance.py
+++ b/tests/test_masterdata_acceptance.py
@@ -1,5 +1,5 @@
 from datetime import date
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import create_engine
@@ -260,7 +260,7 @@ def test_acceptance_confirmation_blocks_tampered_evidence_fingerprint():
         result = assess_master_data_acceptance(
             session, _request(dataset_sha256="4" * 64, coverage_evidence=_valid_coverage()), "submitter"
         )
-        stored = session.get(MasterDataAcceptanceRecord, result.acceptance_id)
+        stored = session.get(MasterDataAcceptanceRecord, UUID(result.acceptance_id))
         stored.population_scope = "tampered-scope"
         session.commit()
         with pytest.raises(ValueError, match="evidence fingerprint changed"):


### PR DESCRIPTION
## Summary
- include `core_hr_snapshot.py` in the M3.18 governance trigger paths
- include the new HR snapshot/personnel-order binding regression suite in lint and test execution
- include the workflow itself in pull-request path triggers
- add explicit approval timestamp to the synthetic approved-policy fixture so the regression exercises the intended snapshot binding path

## Why
The latest `main` commits added HR snapshot binding and tamper/immutability tests, but the existing M3.18 workflow did not trigger on the new module/test paths and did not execute the new regression file. The first CI run then exposed that the new fixture supplied `approved_by` without `approved_at`, which is correctly rejected by the M3.18 policy governance contract. This PR now aligns the fixture with the contract without weakening any production guard.

## Validation
GitHub Actions is the authoritative validation for the resulting branch/PR.