### PR TITLE
feat: start M3.19 master-data readiness gate

### DIFF
--- a/.github/workflows/m3-19-masterdata-readiness.yml
+++ b/.github/workflows/m3-19-masterdata-readiness.yml
@@ -1,0 +1,64 @@
+name: M3.19 Master Data Readiness Gate
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/m3-19-masterdata-readiness.yml"
+      - "src/morva/masterdata/**"
+      - "src/morva/persistence/acceptance_records.py"
+      - "src/morva/persistence/domain_extensions.py"
+      - "src/morva/persistence/enterprise_models.py"
+      - "src/morva/persistence/masterdata_records.py"
+      - "src/morva/persistence/models.py"
+      - "tests/test_masterdata_acceptance.py"
+      - "tests/test_masterdata_readiness.py"
+      - "alembic/versions/0018_master_data_acceptance_integrity_snapshot.py"
+      - "docs/M3_19_MASTER_DATA_READINESS.md"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/m3-19-masterdata-readiness.yml"
+      - "src/morva/masterdata/**"
+      - "src/morva/persistence/acceptance_records.py"
+      - "src/morva/persistence/domain_extensions.py"
+      - "src/morva/persistence/enterprise_models.py"
+      - "src/morva/persistence/masterdata_records.py"
+      - "src/morva/persistence/models.py"
+      - "tests/test_masterdata_acceptance.py"
+      - "tests/test_masterdata_readiness.py"
+      - "alembic/versions/0018_master_data_acceptance_integrity_snapshot.py"
+      - "docs/M3_19_MASTER_DATA_READINESS.md"
+
+jobs:
+  master-data-readiness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: python -m pip install -e '.[dev]'
+      - name: Lint master-data readiness
+        run: >-
+          ruff check
+          src/morva/masterdata/acceptance.py
+          src/morva/masterdata/authoritative.py
+          src/morva/masterdata/models.py
+          src/morva/masterdata/readiness.py
+          src/morva/masterdata/validation.py
+          tests/test_masterdata_acceptance.py
+          tests/test_masterdata_readiness.py
+      - name: Run master-data acceptance and readiness tests
+        run: >-
+          pytest -q
+          tests/test_masterdata_acceptance.py
+          tests/test_masterdata_readiness.py
+      - name: Validate migrations on a clean database
+        env:
+          MORVA_DATABASE_URL: sqlite:///./migration-gate.db
+        run: |
+          rm -f morva.db migration-gate.db
+          alembic upgrade head
+      - name: Compile application
+        run: python -m compileall -q src tests

--- a/docs/M3_19_MASTER_DATA_READINESS.md
+++ b/docs/M3_19_MASTER_DATA_READINESS.md
@@ -1,0 +1,22 @@
+# M3.19 Master Data Readiness Boundary
+
+M3.19 begins the next authoritative-master-data tranche by turning the existing acceptance evidence into a reusable fail-closed readiness gate.
+
+## Implemented
+
+- an accepted `MasterDataAcceptanceRecord` is required before a dataset is considered ready;
+- optional dataset name and exact dataset SHA-256 selectors prevent accidental cross-dataset reuse;
+- authority confirmation evidence must be present on the accepted record;
+- the current master-data integrity validator is re-run at readiness time;
+- the live persisted master-data population counts must match the accepted coverage evidence;
+- the live integrity snapshot hash must match the hash captured at acceptance;
+- the deterministic acceptance evidence fingerprint is recomputed and must match the stored fingerprint;
+- any missing, stale or tampered evidence returns a blocked result rather than allowing silent fallback.
+
+## Non-claims
+
+This gate does not manufacture ministry data, official personnel-order schemas, organizational approval policy, legal rates or any other authoritative evidence. The repository remains an enterprise-validation candidate until the authoritative source package and formal acceptance evidence are supplied.
+
+## Next M3.19 work
+
+The next implementation increment should bind this readiness result into the payroll input boundary so that an unaccepted or drifted organization/personnel/rank/attendance population cannot enter payroll calculation. After that, the authoritative source package can be validated against the same acceptance contract and recorded as formal evidence.

--- a/docs/M3_19_STATUS.md
+++ b/docs/M3_19_STATUS.md
@@ -1,0 +1,14 @@
+# M3.19 Status
+
+M3.19 has started on `feat/m3-19-masterdata-readiness-gate`.
+
+Implemented in this tranche:
+
+- reusable fail-closed master-data readiness verification;
+- accepted authority evidence required for readiness;
+- live integrity snapshot, population coverage and evidence fingerprint rechecked;
+- exact dataset/hash selectors supported;
+- dedicated CI workflow and regression tests;
+- roadmap updated to record M3.19 readiness work.
+
+The next increment is to bind this readiness gate directly to the payroll input boundary. No authoritative ministry dataset or formal organizational approval evidence is fabricated by this implementation.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,7 +34,7 @@
 
 1. Keep exact `main` head green across compilation, Ruff, PostgreSQL migrations, pytest, pip-audit and web build.
 2. Refresh the technical assessment after each material implementation tranche. **M3.16/M3.17 refresh recorded in `docs/ASSESSMENT_2026-09-09.md`; M3.18 personnel-order governance recorded in `docs/M3_17_PERSONNEL_ORDER_LIFECYCLE.md`.**
-3. Complete authoritative organization/personnel/rank/attendance master data. **M3.17 strengthened referential, temporal and workflow-integrity gates; authoritative source confirmation and complete population evidence remain pending.**
+3. Complete authoritative organization/personnel/rank/attendance master data. **M3.17 strengthened referential, temporal and workflow-integrity gates; M3.19 now adds a reusable fail-closed readiness gate that requires accepted, current and untampered master-data evidence. Authoritative source confirmation and complete population evidence remain pending.**
 4. Complete personnel-order lifecycle and approval evidence. **M3.18 implemented immutable order fingerprint binding and fail-closed effective-state verification; authoritative order schema and organizational approval policy remain pending.**
 5. Complete legal component matrix and annual Rule Packs from primary sources.
 6. Complete tax, pension, insurance, loans and judicial-deduction ledgers with approved treatments. **M3.12 governance boundary is implemented; authoritative treatment evidence and approved population-specific rules remain pending.**

--- a/src/morva/masterdata/__init__.py
+++ b/src/morva/masterdata/__init__.py
@@ -1,0 +1,3 @@
+from morva.masterdata.readiness import MasterDataReadinessResult, verify_master_data_readiness
+
+__all__ = ["MasterDataReadinessResult", "verify_master_data_readiness"]

--- a/src/morva/masterdata/readiness.py
+++ b/src/morva/masterdata/readiness.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from morva.masterdata.acceptance import (
+    COVERAGE_KEYS,
+    _current_coverage_evidence,
+    _evidence_fingerprint,
+    _master_data_integrity_snapshot_hash,
+    validate_authoritative_master_data,
+)
+from morva.persistence.acceptance_records import MasterDataAcceptanceRecord
+
+
+@dataclass(frozen=True, slots=True)
+class MasterDataReadinessResult:
+    ready: bool
+    blockers: tuple[str, ...]
+    acceptance_id: str | None
+    dataset_name: str | None
+    dataset_sha256: str | None
+    integrity_snapshot_hash: str | None
+
+
+def verify_master_data_readiness(
+    session: Session,
+    *,
+    dataset_name: str | None = None,
+    dataset_sha256: str | None = None,
+) -> MasterDataReadinessResult:
+    """Fail closed unless an accepted master-data assessment still matches live state."""
+    blockers: list[str] = []
+    query = select(MasterDataAcceptanceRecord).where(MasterDataAcceptanceRecord.status == "accepted")
+    if dataset_name is not None:
+        query = query.where(MasterDataAcceptanceRecord.dataset_name == dataset_name)
+    if dataset_sha256 is not None:
+        query = query.where(MasterDataAcceptanceRecord.dataset_sha256 == dataset_sha256.lower())
+    records = session.scalars(query.order_by(MasterDataAcceptanceRecord.created_at.desc())).all()
+    if not records:
+        return MasterDataReadinessResult(
+            ready=False,
+            blockers=("no accepted master-data assessment is available",),
+            acceptance_id=None,
+            dataset_name=dataset_name,
+            dataset_sha256=dataset_sha256.lower() if dataset_sha256 else None,
+            integrity_snapshot_hash=None,
+        )
+
+    record = records[0]
+    if not record.accepted_by or not record.accepted_at or not record.authority_confirmation_reference:
+        blockers.append("accepted master-data record is missing authority confirmation evidence")
+
+    integrity = validate_authoritative_master_data(session)
+    if integrity.blocking:
+        blockers.append("current authoritative master-data integrity gate is blocking")
+        blockers.extend(
+            f"integrity:{item.code}:{item.entity_id}"
+            for item in integrity.findings
+            if item.severity == "error"
+        )
+
+    current_snapshot_hash = _master_data_integrity_snapshot_hash(session)
+    if current_snapshot_hash != record.integrity_snapshot_hash:
+        blockers.append("master-data integrity snapshot differs from accepted evidence")
+
+    current_coverage = _current_coverage_evidence(session)
+    stored_coverage = record.coverage_evidence or {}
+    if any(stored_coverage.get(key) != current_coverage[key] for key in COVERAGE_KEYS):
+        blockers.append("master-data population coverage differs from accepted evidence")
+
+    if record.status == "accepted":
+        from morva.masterdata.acceptance import MasterDataAcceptanceRequest
+
+        request = MasterDataAcceptanceRequest(
+            dataset_name=record.dataset_name,
+            schema_version=record.schema_version,
+            source_system=record.source_system,
+            source_uri=record.source_uri,
+            authoritative_source_reference=record.authoritative_source_reference,
+            evidence_reference=record.evidence_reference,
+            evidence_sha256=record.evidence_sha256,
+            population_scope=record.population_scope,
+            coverage_evidence={key: int(stored_coverage[key]) for key in COVERAGE_KEYS if key in stored_coverage},
+            dataset_period=record.dataset_period,
+            dataset_sha256=record.dataset_sha256,
+            row_count=record.row_count,
+            duplicate_key_count=record.duplicate_key_count,
+            rejected_row_count=record.rejected_row_count,
+            schema_valid=record.schema_valid,
+        )
+        if _evidence_fingerprint(request, current_snapshot_hash) != record.evidence_fingerprint:
+            blockers.append("accepted master-data evidence fingerprint is inconsistent")
+
+    return MasterDataReadinessResult(
+        ready=not blockers,
+        blockers=tuple(blockers),
+        acceptance_id=str(record.id),
+        dataset_name=record.dataset_name,
+        dataset_sha256=record.dataset_sha256,
+        integrity_snapshot_hash=current_snapshot_hash,
+    )

--- a/src/morva/masterdata/readiness.py
+++ b/src/morva/masterdata/readiness.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from morva.masterdata.acceptance import (
     COVERAGE_KEYS,
+    MasterDataAcceptanceRequest,
     _current_coverage_evidence,
     _evidence_fingerprint,
     _master_data_integrity_snapshot_hash,
@@ -72,28 +72,25 @@ def verify_master_data_readiness(
     if any(stored_coverage.get(key) != current_coverage[key] for key in COVERAGE_KEYS):
         blockers.append("master-data population coverage differs from accepted evidence")
 
-    if record.status == "accepted":
-        from morva.masterdata.acceptance import MasterDataAcceptanceRequest
-
-        request = MasterDataAcceptanceRequest(
-            dataset_name=record.dataset_name,
-            schema_version=record.schema_version,
-            source_system=record.source_system,
-            source_uri=record.source_uri,
-            authoritative_source_reference=record.authoritative_source_reference,
-            evidence_reference=record.evidence_reference,
-            evidence_sha256=record.evidence_sha256,
-            population_scope=record.population_scope,
-            coverage_evidence={key: int(stored_coverage[key]) for key in COVERAGE_KEYS if key in stored_coverage},
-            dataset_period=record.dataset_period,
-            dataset_sha256=record.dataset_sha256,
-            row_count=record.row_count,
-            duplicate_key_count=record.duplicate_key_count,
-            rejected_row_count=record.rejected_row_count,
-            schema_valid=record.schema_valid,
-        )
-        if _evidence_fingerprint(request, current_snapshot_hash) != record.evidence_fingerprint:
-            blockers.append("accepted master-data evidence fingerprint is inconsistent")
+    request = MasterDataAcceptanceRequest(
+        dataset_name=record.dataset_name,
+        schema_version=record.schema_version,
+        source_system=record.source_system,
+        source_uri=record.source_uri,
+        authoritative_source_reference=record.authoritative_source_reference,
+        evidence_reference=record.evidence_reference,
+        evidence_sha256=record.evidence_sha256,
+        population_scope=record.population_scope,
+        coverage_evidence={key: int(stored_coverage[key]) for key in COVERAGE_KEYS if key in stored_coverage},
+        dataset_period=record.dataset_period,
+        dataset_sha256=record.dataset_sha256,
+        row_count=record.row_count,
+        duplicate_key_count=record.duplicate_key_count,
+        rejected_row_count=record.rejected_row_count,
+        schema_valid=record.schema_valid,
+    )
+    if _evidence_fingerprint(request, current_snapshot_hash) != record.evidence_fingerprint:
+        blockers.append("accepted master-data evidence fingerprint is inconsistent")
 
     return MasterDataReadinessResult(
         ready=not blockers,

--- a/tests/test_masterdata_readiness.py
+++ b/tests/test_masterdata_readiness.py
@@ -1,0 +1,90 @@
+from uuid import UUID
+
+import pytest
+
+from morva.masterdata.acceptance import assess_master_data_acceptance, confirm_master_data_acceptance
+from morva.masterdata.readiness import verify_master_data_readiness
+from morva.persistence.acceptance_records import MasterDataAcceptanceRecord
+from morva.persistence.models import EmployeeRecord
+
+from test_masterdata_acceptance import _add_valid_master_data, _request, _session, _valid_coverage
+
+
+def test_readiness_fails_closed_without_accepted_assessment():
+    with _session() as session:
+        result = verify_master_data_readiness(session)
+        assert result.ready is False
+        assert result.blockers == ("no accepted master-data assessment is available",)
+
+
+def test_readiness_accepts_an_unchanged_authoritative_assessment():
+    with _session() as session:
+        _add_valid_master_data(session)
+        coverage = _valid_coverage()
+        assessed = assess_master_data_acceptance(
+            session, _request(dataset_sha256="8" * 64, coverage_evidence=coverage), "submitter"
+        )
+        confirm_master_data_acceptance(session, assessed.acceptance_id, "authority", "FORMAL-AUTH-2026-008")
+
+        result = verify_master_data_readiness(session, dataset_name="education-masterdata")
+        assert result.ready is True
+        assert result.acceptance_id == assessed.acceptance_id
+        assert result.dataset_sha256 == "8" * 64
+        assert len(result.integrity_snapshot_hash or "") == 64
+
+
+def test_readiness_blocks_after_master_data_changes():
+    with _session() as session:
+        _add_valid_master_data(session)
+        coverage = _valid_coverage()
+        assessed = assess_master_data_acceptance(
+            session, _request(dataset_sha256="9" * 64, coverage_evidence=coverage), "submitter"
+        )
+        confirm_master_data_acceptance(session, assessed.acceptance_id, "authority", "FORMAL-AUTH-2026-009")
+
+        employee = session.query(EmployeeRecord).filter(EmployeeRecord.employee_no.like("GOOD-%")).one()
+        employee.first_name = "Drifted"
+        session.commit()
+
+        result = verify_master_data_readiness(session)
+        assert result.ready is False
+        assert "master-data integrity snapshot differs from accepted evidence" in result.blockers
+
+
+def test_readiness_blocks_tampered_acceptance_record():
+    with _session() as session:
+        _add_valid_master_data(session)
+        coverage = _valid_coverage()
+        assessed = assess_master_data_acceptance(
+            session, _request(dataset_sha256="a" * 64, coverage_evidence=coverage), "submitter"
+        )
+        confirm_master_data_acceptance(session, assessed.acceptance_id, "authority", "FORMAL-AUTH-2026-010")
+
+        record = session.get(MasterDataAcceptanceRecord, UUID(assessed.acceptance_id))
+        assert record is not None
+        record.population_scope = "tampered"
+        session.commit()
+
+        result = verify_master_data_readiness(session)
+        assert result.ready is False
+        assert "accepted master-data evidence fingerprint is inconsistent" in result.blockers
+
+
+def test_readiness_can_target_exact_dataset_hash():
+    with _session() as session:
+        _add_valid_master_data(session)
+        coverage = _valid_coverage()
+        assessed = assess_master_data_acceptance(
+            session, _request(dataset_sha256="b" * 64, coverage_evidence=coverage), "submitter"
+        )
+        confirm_master_data_acceptance(session, assessed.acceptance_id, "authority", "FORMAL-AUTH-2026-011")
+
+        result = verify_master_data_readiness(
+            session, dataset_name="education-masterdata", dataset_sha256="c" * 64
+        )
+        assert result.ready is False
+        assert result.acceptance_id is None
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
## Summary
- add reusable fail-closed master-data readiness verification on top of accepted authority evidence
- re-check live integrity snapshot, population coverage and deterministic evidence fingerprint
- add exact dataset/hash selectors and regression coverage
- add a dedicated M3.19 CI gate
- update roadmap and M3.19 tranche documentation

## Scope
This tranche deliberately does not invent or certify authoritative ministry data, official personnel-order schemas, or organizational policy. It establishes the software-side readiness boundary needed before those authoritative artifacts can be consumed by payroll.

## Next increment
Bind `verify_master_data_readiness()` directly to the payroll input boundary so stale, unaccepted or tampered master data cannot enter payroll calculation.