### PR TITLE
feat: bind M3.19 master-data readiness to payroll

### DIFF
--- a/.github/workflows/m3-19-payroll-readiness.yml
+++ b/.github/workflows/m3-19-payroll-readiness.yml
@@ -1,0 +1,40 @@
+name: M3.19 Payroll Master Data Readiness Binding
+
+on:
+  pull_request:
+    paths:
+      - "src/morva/masterdata/readiness.py"
+      - "src/morva/payroll/readiness_guard.py"
+      - "src/morva/payroll/service.py"
+      - "tests/test_payroll_masterdata_readiness.py"
+      - ".github/workflows/m3-19-payroll-readiness.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/morva/masterdata/readiness.py"
+      - "src/morva/payroll/readiness_guard.py"
+      - "src/morva/payroll/service.py"
+      - "tests/test_payroll_masterdata_readiness.py"
+      - ".github/workflows/m3-19-payroll-readiness.yml"
+
+jobs:
+  payroll-readiness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: python -m pip install -e '.[dev]'
+      - name: Ruff
+        run: >-
+          ruff check
+          src/morva/masterdata/readiness.py
+          src/morva/payroll/readiness_guard.py
+          src/morva/payroll/service.py
+          tests/test_payroll_masterdata_readiness.py
+      - name: Readiness boundary tests
+        run: pytest -q tests/test_payroll_masterdata_readiness.py
+      - name: Compile application
+        run: python -m compileall -q src tests

--- a/src/morva/payroll/service.py
+++ b/src/morva/payroll/service.py
@@ -4,7 +4,10 @@ from datetime import date
 from decimal import Decimal
 from typing import Iterable
 
+from sqlalchemy.orm import Session
+
 from morva.payroll.models import PayrollLine, PayrollResult
+from morva.payroll.readiness_guard import require_master_data_readiness
 
 
 class PayrollService:
@@ -24,6 +27,30 @@ class PayrollService:
             employee_no=employee_no,
             period=self.period_key(period),
             lines=materialized,
+            ruleset_version=ruleset_version,
+        )
+
+    def calculate_checked(
+        self,
+        *,
+        session: Session,
+        employee_no: str,
+        period: date,
+        lines: Iterable[PayrollLine],
+        ruleset_version: str = "draft",
+        dataset_name: str | None = None,
+        dataset_sha256: str | None = None,
+    ) -> PayrollResult:
+        """Calculate payroll only after accepted, untampered master-data readiness."""
+        require_master_data_readiness(
+            session,
+            dataset_name=dataset_name,
+            dataset_sha256=dataset_sha256,
+        )
+        return self.calculate(
+            employee_no=employee_no,
+            period=period,
+            lines=lines,
             ruleset_version=ruleset_version,
         )
 

--- a/tests/test_payroll_masterdata_readiness.py
+++ b/tests/test_payroll_masterdata_readiness.py
@@ -1,0 +1,49 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from morva.payroll.models import PayrollResult
+from morva.payroll.readiness_guard import PayrollReadinessError
+from morva.payroll.service import PayrollService
+from morva.persistence.models import Base
+
+
+@pytest.fixture()
+def session():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    with factory() as value:
+        yield value
+
+
+def test_checked_calculation_fails_closed_without_accepted_master_data(session):
+    with pytest.raises(PayrollReadinessError, match="no accepted master-data assessment"):
+        PayrollService().calculate_checked(
+            session=session,
+            employee_no="E-1",
+            period=date(2026, 9, 1),
+            lines=(),
+        )
+
+
+def test_readiness_error_contains_all_blockers(session):
+    with pytest.raises(PayrollReadinessError) as exc_info:
+        PayrollService().calculate_checked(
+            session=session,
+            employee_no="E-1",
+            period=date(2026, 9, 1),
+            lines=(
+                PayrollService().build_standard_lines(
+                    base_salary=Decimal("1000"), allowances=(), deductions=()
+                )[0],
+            ),
+        )
+    assert exc_info.value.blockers == ("no accepted master-data assessment is available",)
+
+
+def test_readiness_checked_calculation_preserves_calculation_result_shape():
+    assert PayrollResult.__name__ == "PayrollResult"


### PR DESCRIPTION
## Summary
- add a fail-closed payroll readiness guard backed by accepted master-data evidence
- bind the guard to a checked payroll calculation entry point
- add regression tests proving payroll cannot calculate without accepted master-data evidence
- add a dedicated M3.19 CI gate

## Scope
This tranche establishes the software boundary only. It does not invent authoritative ministry data, legal rules, personnel-order schemas, or organizational approval authority.

## Validation
The new CI gate runs Ruff, readiness regression tests, and compilation. Existing repository gates remain authoritative.
